### PR TITLE
Make uptime dynamic fully translatable

### DIFF
--- a/src/commands/Bot/uptime.js
+++ b/src/commands/Bot/uptime.js
@@ -19,11 +19,20 @@ module.exports = class extends Command {
 		const mins = Math.floor(time.asMinutes() - days * 24 * 60 - hours * 60);
 		const secs = Math.floor(time.asSeconds() - days * 24 * 60 * 60 - hours * 60 * 60 - mins * 60);
 
-		let uptime = "";
-		if (days > 0) uptime += `${days} day(s), `;
-		if (hours > 0) uptime += `${hours} hour(s), `;
-		if (mins > 0) uptime += `${mins} minute(s), `;
-		if (secs > 0) uptime += `${secs} second(s)`;
+		const timeStrings = [];
+		if (days > 0) timeStrings.push(`${days} day${days == 1 ? "" : "s"}`);
+		if (hours > 0) timeStrings.push(`${hours} hour${hours == 1 ? "" : "s"}`);
+		if (mins > 0) timeStrings.push(`${mins} minute${mins == 1 ? "" : "s"}`);
+		if (secs > 0) timeStrings.push(`${secs} second${secs == 1 ? "" : "s"}`);
+		
+		const uptime = (() => { // Dynamic assignment
+			const last = timeStrings.pop();
+			if(timeStrings.length > 1)
+				return timeStrings.join(", ") + ", and " + last;
+			else
+				timeStrings.push(last);
+				return timeStrings.join(" and ")
+		})();
 
 		const embed = new Discord.MessageEmbed()
 			.setColor(global.config.embedColor)

--- a/src/commands/Bot/uptime.js
+++ b/src/commands/Bot/uptime.js
@@ -20,20 +20,41 @@ module.exports = class extends Command {
 		const secs = Math.floor(time.asSeconds() - days * 24 * 60 * 60 - hours * 60 * 60 - mins * 60);
 
 		const timeStrings = [];
-		if (days > 0) timeStrings.push(`${days} day${days == 1 ? "" : "s"}`);
-		if (hours > 0) timeStrings.push(`${hours} hour${hours == 1 ? "" : "s"}`);
-		if (mins > 0) timeStrings.push(`${mins} minute${mins == 1 ? "" : "s"}`);
-		if (secs > 0) timeStrings.push(`${secs} second${secs == 1 ? "" : "s"}`);
-		
-		const uptime = (() => { // Dynamic assignment
+		if (days > 0)
+			timeStrings.push(await message.client.bulbutils.translate("uptime_days", message.guild.id, {
+				days_text: days == 1 ? await message.client.bulbutils.translate("days_single") : await message.client.bulbutils.translate("days_multi"),
+				days_value: days.toString(),
+			}));
+		if (hours > 0)
+			timeStrings.push(await message.client.bulbutils.translate("uptime_hours", message.guild.id, {
+				hours_text: hours == 1 ? await message.client.bulbutils.translate("hours_single") : await message.client.bulbutils.translate("hours_multi"),
+				hours_value: hours.toString(),
+			}));
+		if (mins > 0)
+			timeStrings.push(await message.client.bulbutils.translate("uptime_mins", message.guild.id, {
+				mins_text: mins == 1 ? await message.client.bulbutils.translate("mins_single") : await message.client.bulbutils.translate("mins_multi"),
+				mins_value: mins.toString(),
+			}));
+		if (secs > 0)
+			timeStrings.push(await message.client.bulbutils.translate("uptime_secs", message.guild.id, {
+				secs_text: secs == 1 ? await message.client.bulbutils.translate("secs_single") : await message.client.bulbutils.translate("secs_multi"),
+				secs_value: secs.toString(),
+			}));
+
+		if (timeStrings.length === 0)
+			timeStrings.push(await message.client.bulbutils.translate("uptime_secs", message.guild.id, {
+				secs_text: await message.client.bulbutils.translate("secs_multi"),
+				secs_value: (0).toString(),
+			}));
+
+		const uptime = await (async () => { // Dynamic assignment
 			const last = timeStrings.pop();
 			if(timeStrings.length > 1)
-				return timeStrings.join(", ") + ", and " + last;
+				return `${timeStrings.join(", ")},  ${await message.client.bulbutils.translate("and", message.guild.id)} ${last}`;
 			else
 				timeStrings.push(last);
-				return timeStrings.join(" and ")
+				return timeStrings.join(` ${await message.client.bulbutils.translate("and", message.guild.id)} `);
 		})();
-
 		const embed = new Discord.MessageEmbed()
 			.setColor(global.config.embedColor)
 			.setDescription(await this.client.bulbutils.translate("uptime_uptime", message.guild.id, { uptime }))

--- a/src/languages/en-US.json
+++ b/src/languages/en-US.json
@@ -194,6 +194,20 @@
 	"ping_latency": "Bot latency is **{latency_bot}ms**\nWebSocket latency is **{latency_ws}ms**",
 
 	"uptime_uptime": "The current uptime is **{uptime}**",
+	"uptime_days": "{days_value} {days_text}",
+	"uptime_hours": "{hours_value} {hours_text}",
+	"uptime_mins": "{mins_value} {mins_text}",
+	"uptime_secs": "{secs_value} {secs_text}",
+
+	"days_single": "day",
+	"hours_single": "hour",
+	"mins_single": "minute",
+	"secs_single": "second",
+	"days_multi": "days",
+	"hours_multi": "hours",
+	"mins_multi": "minutes",
+	"secs_multi": "seconds",
+	"and": "and",
 
 	"license_license": "📜 This bot is licensed under the MIT license, for more info see the full license **[here](https://github.com/TestersQTs/Bulbbot/blob/master/LICENSE)**",
 

--- a/src/utils/BulbBotUtils.js
+++ b/src/utils/BulbBotUtils.js
@@ -56,6 +56,15 @@ module.exports = class BulbBotUtils {
 		response = response.replace(/({zone})/g, key.zone);
 		response = response.replace(/({until})/g, key.until);
 
+		response = response.replace(/({days_value})/g, key.days_value);
+		response = response.replace(/({hours_value})/g, key.hours_value);
+		response = response.replace(/({mins_value})/g, key.mins_value);
+		response = response.replace(/({secs_value})/g, key.secs_value);
+		response = response.replace(/({days_text})/g, key.days_text);
+		response = response.replace(/({hours_text})/g, key.hours_text);
+		response = response.replace(/({mins_text})/g, key.mins_text);
+		response = response.replace(/({secs_text})/g, key.secs_text);
+
 		response = response.replace(/({nick_old})/g, key.nick_old);
 		response = response.replace(/({nick_new})/g, key.nick_new);
 		response = response.replace(/({role})/g, key.role);


### PR DESCRIPTION
No one asked for this but here it is. There are a lot of new translation strings in en-US.json, so if they aren't translated to other languages before merging there could be a lot of notices about untranslated strings