### PR TITLE
Update clearance handler

### DIFF
--- a/src/languages/en-US.json
+++ b/src/languages/en-US.json
@@ -2,7 +2,7 @@
   "global_executed_by": "Executed by {{user.tag}}",
   "global_execution_cancel": "{{emote_fail}} Command execution cancelled",
   "global_missing_permissions": "{{emote_lock}} Missing permission(s)",
-  "global_missing_permissions_bot": "The bot is missing crucial permissions to perform this command. Please check the bots permissions.\n{{missing}}",
+  "global_missing_permissions_bot": "The bot is missing crucial permissions to perform this command. Please check the bot's permissions.\n{{missing}}",
   "global_cannot_convert": "{{emote_fail}} Cannot convert `{{arg_provided}}` to `{{arg_expected}}`.\n{{emote_wrench}} **Correct usage:** {{usage}}",
   "global_not_found": "{{emote_fail}} Could not find the specified {{type}}. Cannot convert `{{arg_provided}}` to `{{arg_expected}}`.\n{{emote_wrench}} **Correct usage:** {{usage}}",
   "global_not_found_types": {

--- a/src/structures/Command.ts
+++ b/src/structures/Command.ts
@@ -20,7 +20,7 @@ export default class Command {
 	public readonly examples: string[];
 	public readonly userPerms: Readonly<BitField<PermissionString, bigint>>;
 	public readonly clientPerms: Readonly<BitField<PermissionString, bigint>>;
-	public readonly clearance: number;
+	public clearance: number;
 	public readonly subDevOnly: boolean;
 	public readonly devOnly: boolean;
 	public readonly premium: boolean;
@@ -76,24 +76,17 @@ export default class Command {
 		const commandOverride: Record<string, any> | undefined = await clearanceManager.getCommandOverride(message.guild!.id, this.qualifiedName);
 		if (commandOverride !== undefined) {
 			if (!commandOverride["enabled"]) return "";
-			if (commandOverride["clearanceLevel"] > options.clearance) {
-				return await this.client.bulbutils.translate("global_missing_permissions", message.guild?.id, {});
-			}
+			this.clearance = commandOverride["clearanceLevel"]
 		}
 
-		this.client.userClearance = options.clearance;
-		if (this.clearance > options.clearance && !commandOverride) {
-			return await this.client.bulbutils.translate("global_missing_permissions", message.guild?.id, {});
-		}
+		this.client.userClearance = options.clearance
 
-		const userPermCheck: BitField<PermissionString, bigint> = this.userPerms;
-		if (userPermCheck && this.clearance <= options.clearance) {
+		if (this.clearance > options.clearance) {
+			const userPermCheck: BitField<PermissionString, bigint> = this.userPerms;
 			const userMember: GuildMember = message.member!;
 			const missing: boolean = !(userMember.permissions.has(userPermCheck) && userMember.permissionsIn(<GuildChannelResolvable>message.channel).has(userPermCheck)); // !x || !y === !(x && y)
 
-			if (missing) {
-				return await this.client.bulbutils.translate("global_missing_permissions", message.guild?.id, {});
-			}
+			if (missing) return await this.client.bulbutils.translate("global_missing_permissions", message.guild?.id, {});
 		}
 
 		const clientPermCheck: BitField<PermissionString, bigint> = this.clientPerms ? this.client.defaultPerms.add(this.clientPerms) : this.client.defaultPerms;


### PR DESCRIPTION
The old clearance manager only checked for clearance and disregarded if an override was present.

The following changes change the workflow to first check for any overrides and if present update the command clearance to the fetched clearance level. If the user is lacking proper clearance the code checks for default Discord permissions. If the user is lacking both clearance and permissions the missing permissions error should get thrown.