### PR TITLE
Fix nickname changes always logging as a self change

### DIFF
--- a/src/commands/Moderation/nickname.ts
+++ b/src/commands/Moderation/nickname.ts
@@ -58,8 +58,8 @@ export default class extends Command {
 		if (await this.client.bulbutils.resolveUserHandle(context, this.client.bulbutils.checkUser(context, target), target.user)) return;
 
 		if (nickname.length > 32) return context.channel.send(await this.client.bulbutils.translate("nickname_too_long", context.guild?.id, { length: nickname.length.toString() }));
-		if (!nickname && !target.nickname) return context.channel.send(await this.client.bulbutils.translate("already_no_nickname", context.guild?.id, { target: target.user }));
-		if (nickname === target.nickname) return context.channel.send(await this.client.bulbutils.translate("already_has_nickname", context.guild?.id, { target: target.user, nickname: target.nickname }));
+		if (!nickname && !target.nickname) return context.channel.send(await this.client.bulbutils.translate("nickname_no_nickname", context.guild?.id, { target: target.user }));
+		if (nickname === target.nickname) return context.channel.send(await this.client.bulbutils.translate("nickname_same_nickname", context.guild?.id, { target: target.user, nickname: target.nickname }));
 
 		const nickOld: string = target.nickname || target.user.username;
 		let infID: number;
@@ -81,11 +81,11 @@ export default class extends Command {
 			);
 		} catch (e: any) {
 			console.error(e.stack);
-			return context.channel.send(await this.client.bulbutils.translate("change_nick_fail", context.guild?.id, { target: target.user }));
+			return context.channel.send(await this.client.bulbutils.translate("nickname_fail", context.guild?.id, { target: target.user }));
 		}
 
 		return context.channel.send(
-			await this.client.bulbutils.translate(nickname ? "change_nick_success" : "remove_nick_success", context.guild?.id, {
+			await this.client.bulbutils.translate(nickname ? "nickname_success" : "nickname_remove_success", context.guild?.id, {
 				target: target.user,
 				nick_old: nickOld,
 				nick_new: nickname,

--- a/src/events/guild/member/guildMemberUpdate.ts
+++ b/src/events/guild/member/guildMemberUpdate.ts
@@ -1,10 +1,12 @@
 import Event from "../../../structures/Event";
-import { DiscordAPIError, GuildAuditLogs, GuildAuditLogsEntry, GuildMember, User, Util, Permissions } from "discord.js";
+import { DiscordAPIError, GuildAuditLogs, GuildAuditLogsEntry, GuildMember, User, Permissions } from "discord.js";
 import LoggingManager from "../../../utils/managers/LoggingManager";
 import DatabaseManager from "../../../utils/managers/DatabaseManager";
+import InfractionsManager from "../../../utils/managers/InfractionsManager";
 
 const loggingManager: LoggingManager = new LoggingManager();
 const databaseManager: DatabaseManager = new DatabaseManager();
+const infractionsManager: InfractionsManager = new InfractionsManager();
 
 export default class extends Event {
 	constructor(...args: any[]) {
@@ -19,11 +21,11 @@ export default class extends Event {
 		if (oldMember.pending && !newMember.pending && (autoRoleName = (await databaseManager.getConfig(newMember.guild.id))["autorole"]) !== null) await newMember.roles.add(autoRoleName);
 
 		let change: "newrole" | "removedrole" | "nickname";
-		let part: "member" | "role";
+		let part: "member" | "role" | "modAction";
 		let message: string;
 		let audit: GuildAuditLogs;
 		let auditLog: GuildAuditLogsEntry | undefined;
-		let executor: User;
+		let executor: User | null = null;
 
 		if (oldMember.roles.cache.size < newMember.roles.cache.size) change = "newrole";
 		else if (oldMember.roles.cache.size > newMember.roles.cache.size) change = "removedrole";
@@ -35,11 +37,9 @@ export default class extends Event {
 				switch (change) {
 					case "newrole":
 					case "removedrole":
-						part = "role";
 						audit = await newMember.guild.fetchAuditLogs({ limit: 1, type: "MEMBER_ROLE_UPDATE" });
 						break;
 					default:
-						part = "member";
 						audit = await newMember.guild.fetchAuditLogs({ limit: 1, type: "MEMBER_UPDATE" });
 						break;
 				}
@@ -51,21 +51,44 @@ export default class extends Event {
 		}
 		switch (change) {
 			case "nickname":
-				if (auditLog?.changes && auditLog!!.changes[0].key === "nick") executor = <User>auditLog.executor;
-				message = await this.client.bulbutils.translate("event_member_update_nickname", newMember.guild.id, {
-					user: newMember.user,
-					before: oldMember.nickname ?? oldMember.user.username,
-					after: newMember.nickname ?? newMember.user.username,
-					// executor?
-				});
+				part = "member";
+				if (auditLog?.changes && auditLog!!.changes[0].key === "nick") {
+					executor = auditLog.executor;
+					const reason = auditLog.reason ?? await this.client.bulbutils.translate("global_no_reason", newMember.guild.id, {});
+					await infractionsManager.createInfraction(newMember.guild.id, "Manual Nickname", true, reason, newMember.user, executor!);
+					const infID: number = await infractionsManager.getLatestInfraction(newMember.guild.id, executor!.id, newMember.id, "Manual Nickname");
+					const translateKey = (executor === null || executor.id === newMember.id) ? newMember.nickname ? "event_member_update_nickname" : "event_member_remove_nickname"
+					                     : newMember.nickname ?  "nickname_mod_action_log" : "nickname_remove_mod_action_log";
+					part = translateKey.startsWith("event") ? "member" : "modAction";
+					message = await this.client.bulbutils.translate(translateKey, newMember.guild.id, {
+						user: newMember.user,
+						before: oldMember.nickname ?? "none",
+						after: newMember.nickname ?? "none",
+						nick_old: oldMember.nickname ?? "none",
+						nick_new: newMember.nickname ?? "none",
+						infraction_id: infID,
+						reason,
+						action: await this.client.bulbutils.translate(newMember.nickname ? "mod_action_types.nick_change" : "mod_action_types.nick_remove", newMember.guild.id, {}),
+						target: newMember.user,
+						moderator: executor,
+					});
+				} else {
+					message = await this.client.bulbutils.translate(`event_member_${newMember.nickname ? "update" : "remove"}_nickname`, newMember.guild.id, {
+						user: newMember.user,
+						before: oldMember.nickname ?? "none",
+						after: newMember.nickname ?? "none",
+					});
+				}
 				break;
 			case "newrole":
 			case "removedrole":
+				part = "role";
 				const diff = newMember.roles.cache.difference(oldMember.roles.cache);
 				const role = diff.first();
 				if (!role) return;
 
 				if (auditLog) {
+					part = "modAction";
 					const translateKey = change === "newrole" ? "event_member_update_role_add_moderator" : "event_member_update_role_remove_moderator";
 					executor = <User>auditLog.executor;
 					message = await this.client.bulbutils.translate(translateKey, newMember.guild.id, {
@@ -78,12 +101,11 @@ export default class extends Event {
 					message = await this.client.bulbutils.translate(translateKey, newMember.guild.id, {
 						user: newMember.user,
 						role,
-						// executor,
 					});
 				}
 				break;
 		}
 
-		await loggingManager.sendEventLog(this.client, newMember.guild, part!, Util.removeMentions(message));
+		await loggingManager.sendEventLog(this.client, newMember.guild, part!, message);
 	}
 }

--- a/src/events/guild/member/guildMemberUpdate.ts
+++ b/src/events/guild/member/guildMemberUpdate.ts
@@ -60,7 +60,7 @@ export default class extends Event {
 					await infractionsManager.createInfraction(newMember.guild.id, "Manual Nickname", true, reason, newMember.user, executor!);
 					const infID: number = await infractionsManager.getLatestInfraction(newMember.guild.id, executor!.id, newMember.id, "Manual Nickname");
 					const translateKey = (executor === null || executor.id === newMember.id) ? newMember.nickname ? "event_member_update_nickname" : "event_member_remove_nickname"
-					                     : newMember.nickname ?  "nickname_mod_action_log" : "nickname_remove_mod_action_log";
+					                     : newMember.nickname ?  "nickname_mod_log" : "nickname_remove_mod_log";
 					part = translateKey.startsWith("event") ? "member" : "modAction";
 					message = await this.client.bulbutils.translate(translateKey, newMember.guild.id, {
 						user: newMember.user,

--- a/src/events/guild/member/guildMemberUpdate.ts
+++ b/src/events/guild/member/guildMemberUpdate.ts
@@ -45,6 +45,7 @@ export default class extends Event {
 				}
 				auditLog = audit.entries.first();
 				if (<number>auditLog?.createdTimestamp + 3000 < Date.now()) auditLog = undefined;
+				if (!auditLog?.executor) auditLog = undefined;
 			} catch (e) {
 				if (!(e instanceof DiscordAPIError)) throw e;
 			}
@@ -54,6 +55,7 @@ export default class extends Event {
 				part = "member";
 				if (auditLog?.changes && auditLog!!.changes[0].key === "nick") {
 					executor = auditLog.executor;
+					if (executor?.id === this.client.user!.id) return;
 					const reason = auditLog.reason ?? await this.client.bulbutils.translate("global_no_reason", newMember.guild.id, {});
 					await infractionsManager.createInfraction(newMember.guild.id, "Manual Nickname", true, reason, newMember.user, executor!);
 					const infID: number = await infractionsManager.getLatestInfraction(newMember.guild.id, executor!.id, newMember.id, "Manual Nickname");

--- a/src/languages/en-US.json
+++ b/src/languages/en-US.json
@@ -97,6 +97,7 @@
   "event_member_leave_roles": "{{emote_leave}} **{{user.tag}}** `({{user.id}})` has left the server.\n**Account joined:** <t:{{user_joined}}:f>\n**Roles:** {{user_roles}}",
 
   "event_member_update_nickname": "{{emote_warn}} **{{user.tag}}** `({{user.id}})` has changed their nickname from `{{before}}` to `{{after}}`",
+  "event_member_remove_nickname": "{{emote_warn}} **{{user.tag}}** `({{user.id}})` has removed their nickname (was: `{{before}}`)",
   "event_member_update_role_add": "{{emote_add}} The **{{role.name}}** Role has been added to **{{user.tag}}** `({{user.id}})`",
   "event_member_update_role_add_moderator": "{{emote_add}} The **{{role.name}}** Role has been added to **{{user.tag}}** `({{user.id}})` by **{{moderator.tag}}** `({{moderator.id}})`",
   "event_member_update_role_remove": "{{emote_remove}} The **{{role.name}}** Role has been removed from **{{user.tag}}** `({{user.id}})`",
@@ -253,13 +254,13 @@
   "verification_level_error": "{{emote_fail}} Verification level cannot be greater than `4` or less than `0`",
   "verification_level_success": "{{emote_success}} Server verification level changed to `{{level}}`",
 
-  "change_nick_success": "{{emote_success}} Nickname of **{{target.tag}}** `({{target.id}})` has been changed from `{{nick_old}}` to `{{nick_new}}` for **{{reason}}** `[#{{infraction_id}}]`",
-  "remove_nick_success": "{{emote_success}} Nickname removed from **{{target.tag}}** `({{target.id}})` for **{{reason}}** `[#{{infraction_id}}]`",
-  "change_nick_mod_action_log": "{{emote_success}} Nickname of **{{target.tag}}** `({{target.id}})` has been {{action}} from `{{nick_old}}` to `{{nick_new}}` by **{{moderator.tag}}** `({{moderator.id}})` for **{{reason}}** `[#{{infraction_id}}]`",
-  "remove_nick_mod_action_log": "{{emote_success}} Nickname {{action}} from **{{target.tag}}** `({{target.id}})` by **{{moderator.tag}}** `({{moderator.id}})` for **{{reason}}** `[#{{infraction_id}}]`",
-  "change_nick_fail": "{{emote_fail}} Unable to change nickname of **{{target.tag}}** `({{target.id}})`",
-  "already_no_nickname": "{{emote_warn}} **{{target.tag}}** `({{target.id}})` does not have a nickname to remove",
-  "already_has_nickname": "{{emote_warn}} **{{target.tag}}** `({{target.id}})` is already nicknamed `{{nickname}}`",
+  "nickname_success": "{{emote_success}} Nickname of **{{target.tag}}** `({{target.id}})` has been changed from `{{nick_old}}` to `{{nick_new}}` for **{{reason}}** `[#{{infraction_id}}]`",
+  "nickname_remove_success": "{{emote_success}} Nickname removed from **{{target.tag}}** `({{target.id}})` for **{{reason}}** `[#{{infraction_id}}]`",
+  "nickname_mod_action_log": "{{emote_success}} Nickname of **{{target.tag}}** `({{target.id}})` has been {{action}} from `{{nick_old}}` to `{{nick_new}}` by **{{moderator.tag}}** `({{moderator.id}})` for **{{reason}}** `[#{{infraction_id}}]`",
+  "nickname_remove_mod_action_log": "{{emote_success}} Nickname {{action}} from **{{target.tag}}** `({{target.id}})` by **{{moderator.tag}}** `({{moderator.id}})` for **{{reason}}** `[#{{infraction_id}}]`",
+  "nickname_fail": "{{emote_fail}} Unable to change nickname of **{{target.tag}}** `({{target.id}})`",
+  "nickname_no_nickname": "{{emote_warn}} **{{target.tag}}** `({{target.id}})` does not have a nickname to remove",
+  "nickname_same_nickname": "{{emote_warn}} **{{target.tag}}** `({{target.id}})` is already nicknamed `{{nickname}}`",
   "nickname_too_long": "{{emote_warn}} Nickname has too many characters (`{{length}}`). Nicknames are limited to 32 characters",
 
   "ping_latency": "Bot latency is **{{latency_bot}}ms**\nWebSocket latency is **{{latency_ws}}ms**",

--- a/src/languages/en-US.json
+++ b/src/languages/en-US.json
@@ -256,8 +256,8 @@
 
   "nickname_success": "{{emote_success}} Nickname of **{{target.tag}}** `({{target.id}})` has been changed from `{{nick_old}}` to `{{nick_new}}` for **{{reason}}** `[#{{infraction_id}}]`",
   "nickname_remove_success": "{{emote_success}} Nickname removed from **{{target.tag}}** `({{target.id}})` for **{{reason}}** `[#{{infraction_id}}]`",
-  "nickname_mod_action_log": "{{emote_success}} Nickname of **{{target.tag}}** `({{target.id}})` has been {{action}} from `{{nick_old}}` to `{{nick_new}}` by **{{moderator.tag}}** `({{moderator.id}})` for **{{reason}}** `[#{{infraction_id}}]`",
-  "nickname_remove_mod_action_log": "{{emote_success}} Nickname {{action}} from **{{target.tag}}** `({{target.id}})` by **{{moderator.tag}}** `({{moderator.id}})` for **{{reason}}** `[#{{infraction_id}}]`",
+  "nickname_mod_log": "{{emote_warn}} Nickname of **{{target.tag}}** `({{target.id}})` has been {{action}} from `{{nick_old}}` to `{{nick_new}}` by **{{moderator.tag}}** `({{moderator.id}})` for **{{reason}}** `[#{{infraction_id}}]`",
+  "nickname_remove_mod_log": "{{emote_warn}} Nickname {{action}} from **{{target.tag}}** `({{target.id}})` by **{{moderator.tag}}** `({{moderator.id}})` for **{{reason}}** `[#{{infraction_id}}]`",
   "nickname_fail": "{{emote_fail}} Unable to change nickname of **{{target.tag}}** `({{target.id}})`",
   "nickname_no_nickname": "{{emote_warn}} **{{target.tag}}** `({{target.id}})` does not have a nickname to remove",
   "nickname_same_nickname": "{{emote_warn}} **{{target.tag}}** `({{target.id}})` is already nicknamed `{{nickname}}`",

--- a/src/utils/managers/InfractionsManager.ts
+++ b/src/utils/managers/InfractionsManager.ts
@@ -253,7 +253,7 @@ export default class {
 		await loggingManager.sendModActionPreformatted(
 			client,
 			guild,
-			await client.bulbutils.translate(nickNew ? "nickname_mod_action_log" : "nickname_remove_mod_action_log", guild.id, {
+			await client.bulbutils.translate(nickNew ? "nickname_mod_log" : "nickname_remove_mod_log", guild.id, {
 				action: await client.bulbutils.translate(nickNew ? "mod_action_types.nick_change" : "mod_action_types.nick_remove", guild.id, { client: client }),
 				target: target.user,
 				nick_old: nickOld,

--- a/src/utils/managers/InfractionsManager.ts
+++ b/src/utils/managers/InfractionsManager.ts
@@ -253,7 +253,7 @@ export default class {
 		await loggingManager.sendModActionPreformatted(
 			client,
 			guild,
-			await client.bulbutils.translate(nickNew ? "change_nick_mod_action_log" : "remove_nick_mod_action_log", guild.id, {
+			await client.bulbutils.translate(nickNew ? "nickname_mod_action_log" : "nickname_remove_mod_action_log", guild.id, {
 				action: await client.bulbutils.translate(nickNew ? "mod_action_types.nick_change" : "mod_action_types.nick_remove", guild.id, { client: client }),
 				target: target.user,
 				nick_old: nickOld,

--- a/src/utils/managers/LoggingManager.ts
+++ b/src/utils/managers/LoggingManager.ts
@@ -111,7 +111,7 @@ export default class {
 	public async sendEventLog(
 		client: BulbBotClient,
 		guild: Guild,
-		part: Exclude<LoggingPartString, "modAction">,
+		part: LoggingPartString,
 		log: string,
 		extra: string | MessageEmbed[] | null = null,
 	): Promise<void> {


### PR DESCRIPTION
Will now be recorded and reported as a mod action when appropriate. The nickname-removed strings will also now be used when appropriate
Resolves #222 