### PR TITLE
Automod timeouts

### DIFF
--- a/src/commands/Configuration/configure/automod/limit.ts
+++ b/src/commands/Configuration/configure/automod/limit.ts
@@ -16,7 +16,7 @@ export default class extends SubCommand {
 			minArgs: 3,
 			maxArgs: 3,
 			argList: ["part:string", "limit:number", "timeout:number"],
-			usage: "<part> <limit>",
+			usage: "<part> <limit> <timeout>",
 		});
 	}
 
@@ -55,6 +55,7 @@ export default class extends SubCommand {
 			);
 
 		if (timeout > 30) return context.channel.send(await this.client.bulbutils.translate("automod_timeout_too_large", context.guild?.id, {}));
+		if (timeout < 3) return context.channel.send(await this.client.bulbutils.translate("automod_timeout_too_small", context.guild?.id, {}))
 
 		const part: AutoModAntiSpamPart = AutoModPart[partString];
 		await databaseManager.automodSetLimit(context.guild!.id, part, limit);

--- a/src/commands/Configuration/configure/automod/limit.ts
+++ b/src/commands/Configuration/configure/automod/limit.ts
@@ -13,9 +13,9 @@ export default class extends SubCommand {
 		super(client, parent, {
 			name: "limit",
 			clearance: 75,
-			minArgs: 2,
-			maxArgs: 2,
-			argList: ["part:string", "limit:number"],
+			minArgs: 3,
+			maxArgs: 3,
+			argList: ["part:string", "limit:number", "timeout:number"],
 			usage: "<part> <limit>",
 		});
 	}
@@ -23,6 +23,7 @@ export default class extends SubCommand {
 	public async run(context: CommandContext, args: string[]): Promise<void | Message> {
 		const partArg = args[0];
 		const limit = Number(args[1]);
+		const timeout = Number(args[2]);
 
 		const partexec = /^(message|mention)s?$/.exec(partArg.toLowerCase());
 		if (!partexec)
@@ -44,13 +45,25 @@ export default class extends SubCommand {
 				}),
 			);
 
+		if (isNaN(timeout))
+			return context.channel.send(
+				await this.client.bulbutils.translate("global_cannot_convert", context.guild?.id, {
+					arg_provided: args[2],
+					arg_expected: "timeout:int",
+					usage: this.usage,
+				}),
+			);
+
+		if (timeout > 30) return context.channel.send(await this.client.bulbutils.translate("automod_timeout_too_large", context.guild?.id, {}));
+
 		const part: AutoModAntiSpamPart = AutoModPart[partString];
 		await databaseManager.automodSetLimit(context.guild!.id, part, limit);
+		await databaseManager.automodSetTimeout(context.guild!.id, part, timeout * 1000);
 
 		await context.channel.send(
 			await this.client.bulbutils.translate("automod_updated_limit", context.guild!.id, {
 				category: partArg,
-				limit,
+				limit: `${limit}/${timeout}s`,
 			}),
 		);
 	}

--- a/src/languages/en-US.json
+++ b/src/languages/en-US.json
@@ -168,6 +168,7 @@
   "automod_disabled_part": "{{emote_success}} Successfully disabled AutoMod category `{{category}}`",
 
   "automod_timeout_too_large": "{{emote_fail}} The timeout limit cannot be larger than `30 seconds`",
+  "automod_timeout_too_small": "{{emote_fail}} The timeout limit cannot be lower than `3 seconds`",
 
   "automod_settings_header": "AutoMod settings for {{guild.name}}",
   "automod_settings_enabled": "**Enabled:** {{enabled}}",

--- a/src/languages/en-US.json
+++ b/src/languages/en-US.json
@@ -160,12 +160,14 @@
   "automod_add_success": "{{emote_success}} Successfully added item(s) `{{item}}` to `{{category}}`.",
   "automod_remove_success": "{{emote_success}} Successfully removed item(s) `{{item}}` from `{{category}}`",
 
-  "automod_updated_limit": "{{emote_success}} Successfully updated the limit for `{{category}}` with a new limit of `{{limit}}`",
+  "automod_updated_limit": "{{emote_success}} Successfully set the limit for `{{category}}` to `{{limit}}`",
   "automod_updated_punishment": "{{emote_success}} Successfully updated the punishment for `{{category}}` to `{{punishment}}`",
 
   "automod_enabled": "{{emote_success}} Successfully enabled AutoMod in the server.",
   "automod_disabled": "{{emote_success}} Successfully disabled AutoMod in the server.",
   "automod_disabled_part": "{{emote_success}} Successfully disabled AutoMod category `{{category}}`",
+
+  "automod_timeout_too_large": "{{emote_fail}} The timeout limit cannot be larger than `30 seconds`",
 
   "automod_settings_header": "AutoMod settings for {{guild.name}}",
   "automod_settings_enabled": "**Enabled:** {{enabled}}",

--- a/src/utils/managers/DatabaseManager.ts
+++ b/src/utils/managers/DatabaseManager.ts
@@ -319,6 +319,22 @@ export default class {
 		});
 	}
 
+	public async automodSetTimeout(guildID: Snowflake, part: AutoModAntiSpamPart, timeout: number): Promise<void> {
+		const dbkey: string = (function (part) {
+			switch (part) {
+				case AutoModPart.message:
+					return "timeoutMessages";
+				case AutoModPart.mention:
+					return "timeoutMentions";
+			}
+		})(part);
+
+		await sequelize.query(`UPDATE automods SET "${dbkey}" = $Timeout WHERE id = (SELECT id FROM guilds WHERE "guildId" = $GuildID)`, {
+			bind: { Timeout: timeout, Part: dbkey, GuildID: guildID },
+			type: QueryTypes.UPDATE,
+		});
+	}
+
 	public async automodSetLimit(guildID: Snowflake, part: AutoModAntiSpamPart, limit: number): Promise<void> {
 		const dbkey: string = (function (part) {
 			switch (part) {


### PR DESCRIPTION
Added the ability to edit automod timeouts for `messages` and `mentions`. (Both are capped at 30s per mention/message in the cache)