### PR TITLE
convert missed name

### DIFF
--- a/src/commands/Bot/help.ts
+++ b/src/commands/Bot/help.ts
@@ -10,7 +10,7 @@ export default class extends Command {
 			description: "Gets useful information about a given command",
 			category: "Bot",
 			usage: "<command> [subcommand...]",
-			argList: ["command:string"],
+			argList: ["command:String"],
 			examples: ["help ping"],
 			minArgs: 1,
 			maxArgs: -1,


### PR DESCRIPTION
Just a minor change: this PR edits the type of the arg in `help` command, missed on:
- #319 