### PR TITLE
bug/ench: day 1 bug fixes of the avatar hashes automod feature

### DIFF
--- a/src/commands/Configuration/configure/automod/add.ts
+++ b/src/commands/Configuration/configure/automod/add.ts
@@ -79,16 +79,18 @@ export default class extends SubCommand {
 			items = hash.filter(h => h);
 		}
 
-		if (errors.length > 0) context.channel.send(errors.join("\n"));
-
 		const result = await databaseManager.automodAppend(context.guild!.id, part, items);
 
 		if (!result.added.length) return context.channel.send(await this.client.bulbutils.translate("automod_already_in_database", context.guild!.id, { item: items.join("`, `") }));
-		await context.channel.send(
+
+		const msg = [
+			errors.length > 0 ? errors.join("\n") + "\n\n" : "",
 			await this.client.bulbutils.translate("automod_add_success", context.guild!.id, {
 				category: partArg,
 				item: result.added.join("`, `"),
 			}),
-		);
+		];
+
+		await context.channel.send(msg.join(""));
 	}
 }

--- a/src/commands/Configuration/configure/automod/remove.ts
+++ b/src/commands/Configuration/configure/automod/remove.ts
@@ -50,7 +50,7 @@ export default class extends SubCommand {
 			const hash = await Promise.all(
 				items.map(async item => {
 					const user: User | undefined = await this.client.bulbfetch.getUser(item!.replace(NonDigits, ""));
-					if (!user) return undefined;
+					if (!user) return item;
 					const buffer = await axios.get(user?.displayAvatarURL()!, {
 						responseType: "arraybuffer",
 					});

--- a/src/events/guild/member/guildMemberAdd.ts
+++ b/src/events/guild/member/guildMemberAdd.ts
@@ -29,7 +29,7 @@ export default class extends Event {
 		);
 
 		const automod: AutoModConfiguration = await databaseManager.getAutoModConfig(member.guild.id);
-		if (automod.avatarHashes.length > 0 && automod.punishmentAvatarBans) {
+		if (automod.enabled && automod.avatarHashes.length > 0 && automod.punishmentAvatarBans) {
 			const buffer = await axios.get(member?.displayAvatarURL()!, {
 				responseType: "arraybuffer",
 			});
@@ -50,7 +50,9 @@ export default class extends Event {
 					await this.client.bulbutils.translate("automod_violation_avatar_log", member.guild.id, {
 						user: member.user,
 						punishment,
+						hash: avatarHash,
 					}),
+					buffer.data,
 				);
 			}
 		}

--- a/src/languages/en-US.json
+++ b/src/languages/en-US.json
@@ -198,6 +198,7 @@
 	"automod_already_in_database": "{{emote_warn}} Item(s) `{{item}}` is/are already in the AutoMod database.",
 	"automod_add_success": "{{emote_success}} Successfully added item(s) `{{item}}` to `{{category}}`.",
 	"automod_remove_success": "{{emote_success}} Successfully removed item(s) `{{item}}` from `{{category}}`",
+	"automod_invalid_input": "{{emote_warn}} Item `{{item}}` was not a valid input for that automod category",
 
 	"automod_updated_limit": "{{emote_success}} Successfully set the limit for `{{category}}` to `{{limit}}`",
 	"automod_updated_punishment": "{{emote_success}} Successfully updated the punishment for `{{category}}` to `{{punishment}}`",

--- a/src/languages/en-US.json
+++ b/src/languages/en-US.json
@@ -232,7 +232,7 @@
 	"automod_violation_website_reason": "Violated `FORBIDDEN_WEBSITE` check in #{{channel.name}}",
 	"automod_violation_website_log": "{{emote_warn}} **{{target.tag}}** `({{target.id}})` has violated the `FORBIDDEN_WEBSITE` check in <#{{channel.id}}> | Punishment: **{{punishment}}**\n```{{message}}```",
 	"automod_violation_avatar_reason": "Violated `BANNED_AVATARS` check",
-	"automod_violation_avatar_log": "{{emote_warn}} **{{user.tag}}** `({{user.id}})` has violated the `BANNED_AVATARS` check | Punishment: **{{punishment}}**",
+	"automod_violation_avatar_log": "{{emote_warn}} **{{user.tag}}** `({{user.id}})` has violated the `BANNED_AVATARS` check | Punishment: **{{punishment}}**\n**Hash:** {{hash}}",
 
 	"jumbo_start": "{{emote_loading}} Generating emoji... This might take a while",
 	"jumbo_too_many": "{{emote_warn}} Too many emojis provided. The bot currently only supports a max of 10 emojis at a time.",

--- a/src/utils/managers/LoggingManager.ts
+++ b/src/utils/managers/LoggingManager.ts
@@ -1,5 +1,5 @@
 import BulbBotClient from "../../structures/BulbBotClient";
-import { Guild, MessageAttachment, MessageEmbed, NewsChannel, Snowflake, TextChannel, User } from "discord.js";
+import { Guild, MessageEmbed, NewsChannel, Snowflake, TextChannel, User } from "discord.js";
 import DatabaseManager from "./DatabaseManager";
 import * as Emotes from "../../emotes.json";
 import { defaultPerms } from "../../Config";

--- a/src/utils/managers/LoggingManager.ts
+++ b/src/utils/managers/LoggingManager.ts
@@ -1,5 +1,5 @@
 import BulbBotClient from "../../structures/BulbBotClient";
-import { Guild, MessageEmbed, NewsChannel, Snowflake, TextChannel, User } from "discord.js";
+import { Guild, MessageAttachment, MessageEmbed, NewsChannel, Snowflake, TextChannel, User } from "discord.js";
 import DatabaseManager from "./DatabaseManager";
 import * as Emotes from "../../emotes.json";
 import { defaultPerms } from "../../Config";
@@ -146,7 +146,7 @@ export default class {
 		await modChannel.send(`\`[${moment().tz(zone).format("hh:mm:ssa z")}]\` ${log}`);
 	}
 
-	public async sendAutoModLog(client: BulbBotClient, guild: Guild, log: string) {
+	public async sendAutoModLog(client: BulbBotClient, guild: Guild, log: string, buffer?: Buffer) {
 		const dbGuild: LoggingConfiguration = await databaseManager.getLoggingConfig(guild.id);
 		const zone: string = client.bulbutils.timezones[await databaseManager.getTimezone(guild.id)];
 
@@ -154,8 +154,20 @@ export default class {
 
 		const modChannel: TextChannel = <TextChannel>client.channels.cache.get(dbGuild.automod);
 		if (!modChannel?.guild.me?.permissionsIn(modChannel).has(defaultPerms)) return;
+		let files: any = null;
 
-		await modChannel.send(`\`[${moment().tz(zone).format("hh:mm:ssa z")}]\` ${log}`);
+		if (buffer)
+			files = [
+				{
+					attachment: buffer,
+					name: "avatar.png",
+				},
+			];
+
+		await modChannel.send({
+			content: `\`[${moment().tz(zone).format("hh:mm:ssa z")}]\` ${log}`,
+			files,
+		});
 	}
 
 	private async betterActions(client: BulbBotClient, guildID: Snowflake, action: string): Promise<string> {


### PR DESCRIPTION
- the logs now show avatar and hash of the user that was found using a bannad avatar
- you are now able to remove banned avatars with the hash
- errors will be show when a invalid user id is passed to the automod add
- fixed a that caused the bot to still use the avatar bans even tho the automod is disabled

Thanks to Bryth#1086 `(231714802261557249)` for these changes