### PR TITLE
Unban/multi-unban commands fixes

### DIFF
--- a/src/commands/Moderation/multiunban.ts
+++ b/src/commands/Moderation/multiunban.ts
@@ -53,7 +53,7 @@ export default class extends Command {
 			const targetID: Snowflake = targets[i].replace(NonDigits, "")
 
 			let infID: number;
-			let target = await this.client.bulbfetch.getUser(targetID);
+			const target = await this.client.bulbfetch.getUser(targetID);
 			if (!target) {
 				await context.channel.send(
 					await this.client.bulbutils.translate("global_not_found", context.guild?.id, {

--- a/src/commands/Moderation/unban.ts
+++ b/src/commands/Moderation/unban.ts
@@ -32,9 +32,6 @@ export default class extends Command {
 		let reason: string = args.slice(1).join(" ");
 		let infID: number;
 
-		const banList = await context.guild?.bans.fetch();
-		const bannedUser = banList?.find(user => user.user.id === targetID);
-
 		if (!target)
 			return await context.channel.send(
 				await this.client.bulbutils.translate("global_not_found", context.guild?.id, {
@@ -44,6 +41,10 @@ export default class extends Command {
 					usage: this.usage,
 				}),
 			);
+
+		const banList = await context.guild?.bans.fetch();
+		const bannedUser = banList?.find(user => user.user.id === targetID);
+
 		if (!bannedUser) return context.channel.send(await this.client.bulbutils.translate("not_banned", context.guild?.id, { target }));
 
 		if (!reason) reason = await this.client.bulbutils.translate("global_no_reason", context.guild?.id, {});


### PR DESCRIPTION
This PR:
- Removes a unnecessary API call when using the `unban` with an invalid ID
- Fixes a bug where the bot didn't check if the specified user was banned before trying to unban them using the `multiunban` command