### PR TITLE
Multi commands improvements

### DIFF
--- a/src/commands/Moderation/multiban.ts
+++ b/src/commands/Moderation/multiban.ts
@@ -28,7 +28,16 @@ export default class extends Command {
 	}
 
 	public async run(context: CommandContext, args: string[]): Promise<void | Message> {
-		const targets: RegExpMatchArray = args.slice(0).join(" ").match(UserMentionAndID) ?? [];
+		let targets: RegExpMatchArray = <RegExpMatchArray>args.slice(0).join(" ").match(UserMentionAndID);
+		targets = [...new Set(targets)];
+
+		if (!targets.length)
+			return context.channel.send(
+				await this.client.bulbutils.translate("action_multi_no_targets", context.guild?.id, {
+					usage: this.usage,
+				}),
+			);
+
 		let reason: string = args.slice(targets.length).join(" ").replace(UserMentionAndID, "");
 
 		if (reason === "") reason = await this.client.bulbutils.translate("global_no_reason", context.guild?.id, {});

--- a/src/commands/Moderation/multiban.ts
+++ b/src/commands/Moderation/multiban.ts
@@ -29,7 +29,7 @@ export default class extends Command {
 
 	public async run(context: CommandContext, args: string[]): Promise<void | Message> {
 		let targets: RegExpMatchArray = <RegExpMatchArray>args.slice(0).join(" ").match(UserMentionAndID);
-		targets = [...new Set(targets)];
+		targets = [...new Set(targets.map(target => target.replace(NonDigits, "")))];
 
 		if (!targets.length)
 			return context.channel.send(

--- a/src/commands/Moderation/multikick.ts
+++ b/src/commands/Moderation/multikick.ts
@@ -27,16 +27,16 @@ export default class extends Command {
 	}
 
 	public async run(context: CommandContext, args: string[]): Promise<void | Message> {
-		const targets: RegExpMatchArray = <RegExpMatchArray>args.slice(0).join(" ").match(UserMentionAndID);
-		if (targets === null)
-			return context.channel.send(
-				await this.client.bulbutils.translate("global_not_found", context.guild?.id, {
-					type: await this.client.bulbutils.translate("global_not_found_types.member", context.guild?.id, {}),
-					arg_expected: "member:Member",
-					arg_provided: args[0],
-					usage: this.usage,
-				}),
-			);
+		let targets: RegExpMatchArray = <RegExpMatchArray>args.slice(0).join(" ").match(UserMentionAndID);
+		targets = [...new Set(targets)];
+
+		if (!targets.length)
+		return context.channel.send(
+			await this.client.bulbutils.translate("action_multi_no_targets", context.guild?.id, {
+				usage: this.usage,
+			}),
+		);
+
 		let reason: string = args.slice(targets.length).join(" ").replace(UserMentionAndID, "");
 
 		if (reason === "") reason = await this.client.bulbutils.translate("global_no_reason", context.guild?.id, {});

--- a/src/commands/Moderation/multikick.ts
+++ b/src/commands/Moderation/multikick.ts
@@ -28,7 +28,7 @@ export default class extends Command {
 
 	public async run(context: CommandContext, args: string[]): Promise<void | Message> {
 		let targets: RegExpMatchArray = <RegExpMatchArray>args.slice(0).join(" ").match(UserMentionAndID);
-		targets = [...new Set(targets)];
+		targets = [...new Set(targets.map(target => target.replace(NonDigits, "")))];
 
 		if (!targets.length)
 		return context.channel.send(

--- a/src/commands/Moderation/multiunban.ts
+++ b/src/commands/Moderation/multiunban.ts
@@ -29,7 +29,7 @@ export default class extends Command {
 
 	public async run(context: CommandContext, args: string[]): Promise<void | Message> {
 		let targets: RegExpMatchArray = <RegExpMatchArray>args.slice(0).join(" ").match(UserMentionAndID);
-		targets = [...new Set(targets)];
+		targets = [...new Set(targets.map(target => target.replace(NonDigits, "")))];
 
 		if (!targets.length)
 			return context.channel.send(

--- a/src/commands/Moderation/multiunban.ts
+++ b/src/commands/Moderation/multiunban.ts
@@ -28,7 +28,16 @@ export default class extends Command {
 	}
 
 	public async run(context: CommandContext, args: string[]): Promise<void | Message> {
-		const targets: RegExpMatchArray = <RegExpMatchArray>args.slice(0).join(" ").match(UserMentionAndID);
+		let targets: RegExpMatchArray = <RegExpMatchArray>args.slice(0).join(" ").match(UserMentionAndID);
+		targets = [...new Set(targets)];
+
+		if (!targets.length)
+			return context.channel.send(
+				await this.client.bulbutils.translate("action_multi_no_targets", context.guild?.id, {
+					usage: this.usage,
+				}),
+			);
+
 		let reason: string = args.slice(targets.length).join(" ").replace(UserMentionAndID, "");
 
 		if (reason === "") reason = await this.client.bulbutils.translate("global_no_reason", context.guild?.id, {});

--- a/src/commands/Moderation/multiwarn.ts
+++ b/src/commands/Moderation/multiwarn.ts
@@ -25,7 +25,9 @@ export default class extends Command {
 
 	public async run(context: CommandContext, args: string[]): Promise<void | Message> {
 		let targets: RegExpMatchArray = <RegExpMatchArray>args.slice(0).join(" ").match(UserMentionAndID);
-		targets = [...new Set(targets)];
+		console.log(targets);
+		targets = [...new Set(targets.map(target => target.replace(NonDigits, "")))];
+		console.log(targets);
 
 		if (!targets.length)
 			return context.channel.send(

--- a/src/commands/Moderation/multiwarn.ts
+++ b/src/commands/Moderation/multiwarn.ts
@@ -24,7 +24,16 @@ export default class extends Command {
 	}
 
 	public async run(context: CommandContext, args: string[]): Promise<void | Message> {
-		const targets: RegExpMatchArray = <RegExpMatchArray>args.slice(0).join(" ").match(UserMentionAndID);
+		let targets: RegExpMatchArray = <RegExpMatchArray>args.slice(0).join(" ").match(UserMentionAndID);
+		targets = [...new Set(targets)];
+
+		if (!targets.length)
+			return context.channel.send(
+				await this.client.bulbutils.translate("action_multi_no_targets", context.guild?.id, {
+					usage: this.usage,
+				}),
+			);
+
 		let reason: string = args.slice(targets?.length).join(" ").replace(UserMentionAndID, "");
 
 		if (reason === "") reason = await this.client.bulbutils.translate("global_no_reason", context.guild?.id, {});
@@ -57,7 +66,7 @@ export default class extends Command {
 				);
 				continue;
 			}
-			if (await this.client.bulbutils.resolveUserHandle(context, await this.client.bulbutils.checkUser(context, target), target.user)) continue;
+			if (await this.client.bulbutils.resolveUserHandle(context, this.client.bulbutils.checkUser(context, target), target.user)) continue;
 
 			infID = await infractionsManager.warn(
 				this.client,

--- a/src/commands/Moderation/multiwarn.ts
+++ b/src/commands/Moderation/multiwarn.ts
@@ -25,9 +25,7 @@ export default class extends Command {
 
 	public async run(context: CommandContext, args: string[]): Promise<void | Message> {
 		let targets: RegExpMatchArray = <RegExpMatchArray>args.slice(0).join(" ").match(UserMentionAndID);
-		console.log(targets);
 		targets = [...new Set(targets.map(target => target.replace(NonDigits, "")))];
-		console.log(targets);
 
 		if (!targets.length)
 			return context.channel.send(

--- a/src/languages/en-US.json
+++ b/src/languages/en-US.json
@@ -291,6 +291,7 @@
 
 	"action_success_multi": "{{emote_success}} {{full_list}} have been {{action}} for **{{reason}}**",
 	"action_multi_less_than_2": "{{emote_warn}} Selected less than 2 targets. Executing normal {{action}} instead",
+	"action_multi_no_targets": "{{emote_fail}} No valid targets were found in your message.\n{{emote_wrench}} **Correct usage:** {{usage}}",
 	"action_multi_types": {
 		"ban": "ban",
 		"kick": "kick",


### PR DESCRIPTION
- Remove dupes from multi commands arguments
- Fixes a bug where the bot tried to access the length property of multi commands targets even though it was null
- Adds an error message to handle the case where no valid arguments are passed to a multi command