### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/commands/Admin/admin/botfarm.ts
+++ b/src/commands/Admin/admin/botfarm.ts
@@ -61,7 +61,7 @@ function dynamicSort(property: any) {
 	var sortOrder = 1;
 	if (property[0] === "-") {
 		sortOrder = -1;
-		property = property.substr(1);
+		property = property.slice(1);
 	}
 	return function (a: any, b: any) {
 		var result = a[property] < b[property] ? -1 : a[property] > b[property] ? 1 : 0;

--- a/src/commands/Configuration/configure/logging.ts
+++ b/src/commands/Configuration/configure/logging.ts
@@ -30,7 +30,7 @@ async function logging(interaction: MessageComponentInteraction, client: BulbBot
 			label: channel.name,
 			value: channel.id,
 			emoji: Emoji.channel.TEXT,
-			description: (channel as TextChannel).topic ? ((channel as TextChannel).topic?.substr(0, 100) as string) : undefined,
+			description: (channel as TextChannel).topic ? ((channel as TextChannel).topic?.slice(0, 100) as string) : undefined,
 		});
 	});
 


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.