### PR TITLE
Lint/remove assertions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -38,6 +38,7 @@
         "@typescript-eslint/no-var-requires": "off",
         "@typescript-eslint/no-empty-function": "off",
         "@typescript-eslint/no-non-null-assertion": "error",
-        "@typescript-eslint/no-inferrable-types": "warn"
+        "@typescript-eslint/no-inferrable-types": "warn",
+        "@typescript-eslint/consistent-type-assertions": "error"
     }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -37,7 +37,7 @@
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-var-requires": "off",
         "@typescript-eslint/no-empty-function": "off",
-        "@typescript-eslint/no-non-null-assertion": "off",
+        "@typescript-eslint/no-non-null-assertion": "error",
         "@typescript-eslint/no-inferrable-types": "warn"
     }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -21,12 +21,12 @@
     ],
     "rules": {
         "no-case-declarations": "off",
-        "no-fallthrough": "warn",
-        "no-empty": "warn",
+        "no-fallthrough": "error",
+        "no-empty": "error",
         "import/no-named-as-default-member": "off",
         "import/no-unresolved": "off",
         "@typescript-eslint/no-unused-vars": [
-            "warn",
+            "error",
             {
                 "varsIgnorePattern": "^_",
                 "argsIgnorePattern": "^_"
@@ -38,7 +38,7 @@
         "@typescript-eslint/no-var-requires": "off",
         "@typescript-eslint/no-empty-function": "off",
         "@typescript-eslint/no-non-null-assertion": "error",
-        "@typescript-eslint/no-inferrable-types": "warn",
+        "@typescript-eslint/no-inferrable-types": "error",
         "@typescript-eslint/consistent-type-assertions": "error"
     }
 }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
 	"devDependencies": {
 		"@messageformat/core": "^3.0.0",
 		"@types/glob": "^7.2.0",
+		"@types/node": "^17.0.23",
 		"@types/sharp": "^0.29.5",
 		"@typescript-eslint/eslint-plugin": "^5.16.0",
 		"@typescript-eslint/parser": "^5.16.0",

--- a/src/commands/Admin/command/load.ts
+++ b/src/commands/Admin/command/load.ts
@@ -29,25 +29,32 @@ export default class extends SubCommand {
 	public async run(context: CommandContext, args: string[]): Promise<void | Message> {
 		const cmd: string = args[0].toLowerCase();
 		let cmdFile = "";
-		let command: Command | undefined = Command.resolve(this.client, args);
+		const resolvedCommand: Command | undefined = Command.resolve(this.client, args);
 		let dirPath: string;
 
 		if (args.length > 1) {
-			if (!command) return context.channel.send(`Cannot load command \`${args[0]}\``);
-			if (command.name === args[args.length - 1]) return await context.channel.send(`Already have command \`${command.qualifiedName}\` loaded (did you mean to use \`reload\` instead?)`);
+			if (!resolvedCommand) return context.channel.send(`Cannot load command \`${args[0]}\``);
+			if (resolvedCommand.name === args[args.length - 1])
+				return await context.channel.send(`Already have command \`${resolvedCommand.qualifiedName}\` loaded (did you mean to use \`reload\` instead?)`);
 			// TODO: Internally call load command (this command) to attempt to load missing command first
-			if (command.name !== args[args.length - 2]) return await context.channel.send(`Cannot load command \`${args.slice(0, command.qualifiedName.split(" ").length + 1).join(" ")}\``);
+			if (resolvedCommand.name !== args[args.length - 2]) return await context.channel.send(`Cannot load command \`${args.slice(0, resolvedCommand.qualifiedName.split(" ").length + 1).join(" ")}\``);
 			cmdFile = args[args.length - 1];
-			dirPath = `${process.cwd()}/build/commands/*/${command.qualifiedName.replace(/ /g, "/")}/${cmdFile}.js`;
+			dirPath = `${process.cwd()}/build/commands/*/${resolvedCommand.qualifiedName.replace(/ /g, "/")}/${cmdFile}.js`;
 		} else {
 			cmdFile = cmd;
 			dirPath = `${process.cwd()}/build/commands/*/${cmdFile}.js`;
 		}
+
+		if (!resolvedCommand) return context.channel.send(`Cannot load command`);
+		let command = resolvedCommand;
+
 		return await globAsync(dirPath).then((commands: any) => {
 			mainLoop: for (const commandFile of commands) {
 				if (args.length > 1) {
-					let currCommand: Command | SubCommand = command!;
-					const cmdChain: string[] = new RegExp(`${process.cwd().replace(/\\/g, "/")}/build/commands/(.+)/${cmdFile}\\.js`).exec(commandFile)![1].split("/").reverse();
+					let currCommand: Command | SubCommand = command;
+					const match = new RegExp(`${process.cwd().replace(/\\/g, "/")}/build/commands/(.+)/${cmdFile}\\.js`).exec(commandFile);
+					if (!match) continue;
+					const cmdChain: string[] = match[1].split("/").reverse();
 					for (const parent of cmdChain.slice(0, -1)) {
 						if (currCommand instanceof SubCommand) {
 							if (currCommand.name !== parent) continue mainLoop;
@@ -67,7 +74,7 @@ export default class extends SubCommand {
 					const loadedCommand = new File.default(this.client, command);
 					// any SubCommand is-a Command
 					if (!(loadedCommand instanceof SubCommand)) return context.channel.send(`Event ${name} doesn't belong in commands!`);
-					command!.subCommands.push(loadedCommand);
+					command.subCommands.push(loadedCommand);
 					command = loadedCommand;
 				} else {
 					delete require.cache[require.resolve(commandFile)];

--- a/src/commands/Admin/command/reload.ts
+++ b/src/commands/Admin/command/reload.ts
@@ -47,7 +47,7 @@ export default class extends SubCommand {
 		// any SubCommand is-a Command
 		if (!(loadedCommand instanceof Command)) return context.channel.send(`Event ${name} doesn't belong in commands!`);
 		if (command instanceof SubCommand) {
-			command.parent.subCommands.push(<SubCommand>loadedCommand);
+			command.parent.subCommands.push(loadedCommand as SubCommand);
 		} else {
 			this.client.commands.set(loadedCommand.name, loadedCommand);
 			if (loadedCommand.aliases.length) {

--- a/src/commands/Admin/eval.ts
+++ b/src/commands/Admin/eval.ts
@@ -47,7 +47,7 @@ export default class extends Command {
 			description += `\n**Type:** ${typeof evaled}`;
 			if (typeof evaled !== "string") evaled = inspect(evaled);
 
-			evaled = evaled.replace(new RegExp(this.client.token!, "g"), `${Buffer.from(this.client.user?.id || "").toString("base64")}.${genString(7)}.${genString(27)}`);
+			evaled = this.client.token ? evaled.replace(new RegExp(this.client.token, "g"), `${Buffer.from(this.client.user?.id || "").toString("base64")}.${genString(7)}.${genString(27)}`) : evaled;
 
 			if (evaled.length < 1950) output = `**Output**\n\`\`\`js\n${evaled}\n\`\`\``;
 			else {

--- a/src/commands/Admin/eval.ts
+++ b/src/commands/Admin/eval.ts
@@ -27,7 +27,7 @@ export default class extends Command {
 				text: await this.client.bulbutils.translate("global_executed_by", context.guild?.id, {
 					user: context.author,
 				}),
-				iconURL: <string>context.author.avatarURL({ dynamic: true }),
+				iconURL: context.author.avatarURL({ dynamic: true }) || "",
 			})
 			.setTimestamp();
 

--- a/src/commands/Admin/stats.ts
+++ b/src/commands/Admin/stats.ts
@@ -58,7 +58,7 @@ export default class extends Command {
 			.setColor(embedColor)
 			.setFooter({
 				text: await this.client.bulbutils.translate("global_executed_by", context.guild.id, { user: context.author }),
-				iconURL: <string>context.author.avatarURL({ dynamic: true }),
+				iconURL: context.author.avatarURL({ dynamic: true }) || "",
 			})
 			.setDescription(desc.join("\n"))
 			.addField("Shard Data", `Recommended number of shards: \`${data.shards}\`\n${shardData.join("")}`, true)

--- a/src/commands/Bot/about.ts
+++ b/src/commands/Bot/about.ts
@@ -48,7 +48,7 @@ export default class extends Command {
 				text: await this.client.bulbutils.translate("global_executed_by", context.guild?.id, {
 					user: context.author,
 				}),
-				iconURL: <string>context.author.avatarURL({ dynamic: true }),
+				iconURL: context.author.avatarURL({ dynamic: true }) || "",
 			})
 			.setTimestamp();
 

--- a/src/commands/Bot/commands.ts
+++ b/src/commands/Bot/commands.ts
@@ -22,7 +22,7 @@ export default class extends Command {
 				text: await this.client.bulbutils.translate("global_executed_by", context.guild?.id, {
 					user: context.author,
 				}),
-				iconURL: <string>context.author.avatarURL({ dynamic: true }),
+				iconURL: context.author.avatarURL({ dynamic: true }) || "",
 			})
 			.setTimestamp();
 

--- a/src/commands/Bot/github.ts
+++ b/src/commands/Bot/github.ts
@@ -23,7 +23,7 @@ export default class extends Command {
 				text: await this.client.bulbutils.translate("global_executed_by", context.guild?.id, {
 					user: context.author,
 				}),
-				iconURL: <string>context.author.avatarURL({ dynamic: true }),
+				iconURL: context.author.avatarURL({ dynamic: true }) || "",
 			})
 			.setTimestamp();
 

--- a/src/commands/Bot/help.ts
+++ b/src/commands/Bot/help.ts
@@ -22,7 +22,7 @@ export default class extends Command {
 		const command = Command.resolve(this.client, args);
 
 		if (!command || !(await command.validateUserPerms(context)))
-			return context.channel.send(await this.client.bulbutils.translate("help_unable_to_find_command", context.guild!.id, { commandName: args[0] }));
+			return context.channel.send(await this.client.bulbutils.translate("help_unable_to_find_command", context.guild?.id, { commandName: args[0] }));
 
 		let msg = `**${Util.escapeMarkdown(context.prefix)}${command.qualifiedName}** ${command.aliases.length !== 0 ? `(${command.aliases.map((alias) => `**${alias}**`).join(", ")})` : ""}\n`;
 		msg += `> ${command.description}\n\n`;

--- a/src/commands/Bot/license.ts
+++ b/src/commands/Bot/license.ts
@@ -22,7 +22,7 @@ export default class extends Command {
 				text: await this.client.bulbutils.translate("global_executed_by", context.guild?.id, {
 					user: context.author,
 				}),
-				iconURL: <string>context.author.avatarURL({ dynamic: true }),
+				iconURL: context.author.avatarURL({ dynamic: true }) || "",
 			})
 			.setTimestamp();
 

--- a/src/commands/Bot/ping.ts
+++ b/src/commands/Bot/ping.ts
@@ -1,7 +1,7 @@
 import Command from "../../structures/Command";
 import CommandContext from "../../structures/CommandContext";
 import * as Config from "../../Config";
-import { ColorResolvable, Message, MessageEmbed } from "discord.js";
+import { Message, MessageEmbed } from "discord.js";
 import BulbBotClient from "../../structures/BulbBotClient";
 
 export default class extends Command {
@@ -20,7 +20,7 @@ export default class extends Command {
 		const apiLatency: number = Math.round(this.client.ws.ping);
 
 		const embed: MessageEmbed = new MessageEmbed()
-			.setColor(<ColorResolvable>Config.embedColor)
+			.setColor(Config.embedColor)
 			.setDescription(
 				await this.client.bulbutils.translate("ping_latency", context.guild?.id, {
 					latency_bot: latency,
@@ -31,7 +31,7 @@ export default class extends Command {
 				text: await this.client.bulbutils.translate("global_executed_by", context.guild?.id, {
 					user: context.author,
 				}),
-				iconURL: <string>context.author.avatarURL({ dynamic: true }),
+				iconURL: context.author.avatarURL({ dynamic: true }) || "",
 			})
 			.setTimestamp();
 

--- a/src/commands/Bot/privacypolicy.ts
+++ b/src/commands/Bot/privacypolicy.ts
@@ -22,7 +22,7 @@ export default class extends Command {
 				text: await this.client.bulbutils.translate("global_executed_by", context.guild?.id, {
 					user: context.author,
 				}),
-				iconURL: <string>context.author.avatarURL({ dynamic: true }),
+				iconURL: context.author.avatarURL({ dynamic: true }) || "",
 			})
 			.setTimestamp();
 

--- a/src/commands/Bot/uptime.ts
+++ b/src/commands/Bot/uptime.ts
@@ -35,7 +35,7 @@ export default class extends Command {
 				text: await this.client.bulbutils.translate("global_executed_by", context.guild?.id, {
 					user: context.author,
 				}),
-				iconURL: <string>context.author.avatarURL({ dynamic: true }),
+				iconURL: context.author.avatarURL({ dynamic: true }) || "",
 			})
 			.setTimestamp();
 

--- a/src/commands/Configuration/banpool/create.ts
+++ b/src/commands/Configuration/banpool/create.ts
@@ -40,7 +40,7 @@ export default class extends SubCommand {
 
 		await sendEventLog(
 			this.client,
-			context.guild!,
+			context.guild,
 			"banpool",
 			await this.client.bulbutils.translate("banpool_create_log", context.guild?.id, {
 				user: context.user,

--- a/src/commands/Configuration/banpool/create.ts
+++ b/src/commands/Configuration/banpool/create.ts
@@ -26,7 +26,7 @@ export default class extends SubCommand {
 		const name: string = args[0];
 
 		if (!(context.guild?.id && (await hasBanpoolLog(context.guild.id)))) return context.channel.send(await this.client.bulbutils.translate("banpool_missing_logging", context.guild?.id, {}));
-		if (await doesbanpoolExist(name)) return context.channel.send(await this.client.bulbutils.translate("banpool_create_name_exists", context.guild?.id, {}));
+		if (await doesbanpoolExist(name)) return context.channel.send(await this.client.bulbutils.translate("banpool_create_name_exists", context.guild.id, {}));
 
 		await createBanpool(context.guild.id, name);
 		!(await joinBanpool(
@@ -42,14 +42,14 @@ export default class extends SubCommand {
 			this.client,
 			context.guild,
 			"banpool",
-			await this.client.bulbutils.translate("banpool_create_log", context.guild?.id, {
+			await this.client.bulbutils.translate("banpool_create_log", context.guild.id, {
 				user: context.user,
 				name,
 			}),
 		);
 
 		context.channel.send(
-			await this.client.bulbutils.translate("banpool_create_success", context.guild?.id, {
+			await this.client.bulbutils.translate("banpool_create_success", context.guild.id, {
 				name,
 			}),
 		);

--- a/src/commands/Configuration/banpool/delete.ts
+++ b/src/commands/Configuration/banpool/delete.ts
@@ -50,7 +50,7 @@ export default class extends SubCommand {
 
 				await sendEventLog(
 					this.client,
-					context.guild!,
+					context.guild,
 					"banpool",
 					await this.client.bulbutils.translate("banpool_delete_success_log", context.guild?.id, {
 						user: context.user,

--- a/src/commands/Configuration/banpool/delete.ts
+++ b/src/commands/Configuration/banpool/delete.ts
@@ -26,7 +26,7 @@ export default class extends SubCommand {
 		const name = args[0];
 
 		if (!(context.guild?.id && (await hasBanpoolLog(context.guild.id)))) return context.channel.send(await this.client.bulbutils.translate("banpool_missing_logging", context.guild?.id, {}));
-		if (!(await haveAccessToPool(context.guild?.id, name))) return context.channel.send(await this.client.bulbutils.translate("banpool_missing_access_not_found", context.guild?.id, {}));
+		if (!(await haveAccessToPool(context.guild.id, name))) return context.channel.send(await this.client.bulbutils.translate("banpool_missing_access_not_found", context.guild.id, {}));
 
 		const row = new MessageActionRow().addComponents([
 			new MessageButton().setStyle("SUCCESS").setLabel("Confirm").setCustomId("confirm"),
@@ -34,7 +34,7 @@ export default class extends SubCommand {
 		]);
 
 		const confirmMsg = await context.channel.send({
-			content: await this.client.bulbutils.translate("banpool_delete_message", context.guild?.id, {}),
+			content: await this.client.bulbutils.translate("banpool_delete_message", context.guild.id, {}),
 			components: [row],
 		});
 

--- a/src/commands/Configuration/banpool/info.ts
+++ b/src/commands/Configuration/banpool/info.ts
@@ -30,7 +30,7 @@ export default class extends SubCommand {
 		for (let i = 0; i < data.length; i++) {
 			const guild = data[i];
 			desc.push(
-				await this.client.bulbutils.translate("banpool_info_desc", context.guild?.id, {
+				await this.client.bulbutils.translate("banpool_info_desc", context.guild.id, {
 					guildId: guild.guildId,
 					createdAt: new Date(guild.createdAt).getTime() / 1000,
 				}),
@@ -39,7 +39,7 @@ export default class extends SubCommand {
 
 		const embed: MessageEmbed = new MessageEmbed()
 			.setAuthor({
-				name: await this.client.bulbutils.translate("banpool_info_top", context.guild?.id, {
+				name: await this.client.bulbutils.translate("banpool_info_top", context.guild.id, {
 					name,
 					amountOfServers: data.length,
 				}),
@@ -47,7 +47,7 @@ export default class extends SubCommand {
 			.setColor(embedColor)
 			.setDescription(desc.join("\n\n"))
 			.setFooter({
-				text: await this.client.bulbutils.translate("global_executed_by", context.guild?.id, {
+				text: await this.client.bulbutils.translate("global_executed_by", context.guild.id, {
 					user: context.author,
 				}),
 				iconURL: context.author.avatarURL({ dynamic: true }) || "",

--- a/src/commands/Configuration/banpool/info.ts
+++ b/src/commands/Configuration/banpool/info.ts
@@ -50,7 +50,7 @@ export default class extends SubCommand {
 				text: await this.client.bulbutils.translate("global_executed_by", context.guild?.id, {
 					user: context.author,
 				}),
-				iconURL: <string>context.author.avatarURL({ dynamic: true }),
+				iconURL: context.author.avatarURL({ dynamic: true }) || "",
 			})
 			.setTimestamp();
 

--- a/src/commands/Configuration/banpool/invite.ts
+++ b/src/commands/Configuration/banpool/invite.ts
@@ -63,7 +63,7 @@ export default class extends SubCommand {
 
 			await sendEventLog(
 				this.client,
-				context.guild!,
+				context.guild,
 				"banpool",
 				await this.client.bulbutils.translate("banpool_invite_success_log", context.guild?.id, {
 					user: context.user,

--- a/src/commands/Configuration/banpool/join.ts
+++ b/src/commands/Configuration/banpool/join.ts
@@ -45,7 +45,7 @@ export default class extends SubCommand {
 		);
 		await sendEventLog(
 			this.client,
-			context.guild!,
+			context.guild,
 			"banpool",
 			await this.client.bulbutils.translate("banpool_join_log", context.guild.id, {
 				user: context.user,

--- a/src/commands/Configuration/banpool/leave.ts
+++ b/src/commands/Configuration/banpool/leave.ts
@@ -42,7 +42,7 @@ export default class extends SubCommand {
 		);
 		await sendEventLog(
 			this.client,
-			context.guild!,
+			context.guild,
 			"banpool",
 			await this.client.bulbutils.translate("banpool_leave_log", context.guild.id, {
 				user: context.user,

--- a/src/commands/Configuration/banpool/list.ts
+++ b/src/commands/Configuration/banpool/list.ts
@@ -36,7 +36,7 @@ export default class extends SubCommand {
 				text: await this.client.bulbutils.translate("global_executed_by", context.guild?.id, {
 					user: context.author,
 				}),
-				iconURL: <string>context.author.avatarURL({ dynamic: true }),
+				iconURL: context.author.avatarURL({ dynamic: true }) || "",
 			})
 			.setTimestamp();
 

--- a/src/commands/Configuration/banpool/remove.ts
+++ b/src/commands/Configuration/banpool/remove.ts
@@ -27,8 +27,8 @@ export default class extends SubCommand {
 		const name: string = args[1];
 
 		if (!(context.guild?.id && (await hasBanpoolLog(context.guild.id)))) return context.channel.send(await this.client.bulbutils.translate("banpool_missing_logging", context.guild?.id, {}));
-		if (!(await haveAccessToPool(context.guild.id, name))) return context.channel.send(await this.client.bulbutils.translate("banpool_missing_access_not_found", context.guild?.id, {}));
-		if (!(await isGuildInPool(guildId, name))) return context.channel.send(await this.client.bulbutils.translate("banpool_remove_not_found", context.guild?.id, {}));
+		if (!(await haveAccessToPool(context.guild.id, name))) return context.channel.send(await this.client.bulbutils.translate("banpool_missing_access_not_found", context.guild.id, {}));
+		if (!(await isGuildInPool(guildId, name))) return context.channel.send(await this.client.bulbutils.translate("banpool_remove_not_found", context.guild.id, {}));
 
 		const row = new MessageActionRow().addComponents([
 			new MessageButton().setStyle("SUCCESS").setLabel("Confirm").setCustomId("confirm"),
@@ -36,7 +36,7 @@ export default class extends SubCommand {
 		]);
 
 		const confirmMsg = await context.channel.send({
-			content: await this.client.bulbutils.translate("banpool_remove_message", context.guild?.id, {}),
+			content: await this.client.bulbutils.translate("banpool_remove_message", context.guild.id, {}),
 			components: [row],
 		});
 

--- a/src/commands/Configuration/banpool/remove.ts
+++ b/src/commands/Configuration/banpool/remove.ts
@@ -62,7 +62,7 @@ export default class extends SubCommand {
 
 				await sendEventLog(
 					this.client,
-					context.guild!,
+					context.guild,
 					"banpool",
 					await this.client.bulbutils.translate("banpool_remove_log", context.guild?.id, {
 						user: context.user,

--- a/src/commands/Configuration/configure.ts
+++ b/src/commands/Configuration/configure.ts
@@ -90,9 +90,9 @@ export default class extends Command {
 		});
 
 		const filter = (i: MessageComponentInteraction) => i.user.id === context.user.id;
-		const collector = context.channel?.createMessageComponentCollector({ filter, time: 60000, max: 1 });
+		const collector = context.channel.createMessageComponentCollector({ filter, time: 60000, max: 1 });
 
-		collector?.on("collect", async (i: MessageComponentInteraction) => {
+		collector.on("collect", async (i: MessageComponentInteraction) => {
 			if (i.isSelectMenu()) {
 				await require(`./configure/${i.values[0]}`).default(i, this.client);
 			}

--- a/src/commands/Configuration/configure/automod/add.ts
+++ b/src/commands/Configuration/configure/automod/add.ts
@@ -95,7 +95,7 @@ async function add(interaction: MessageComponentInteraction, client: BulbBotClie
 				case "remove":
 					collector.stop();
 
-					await databaseManager.automodRemove(interaction.guild?.id as Snowflake, categories[selectedCategory!], selectedItems as string[]);
+					if (selectedCategory) await databaseManager.automodRemove(interaction.guild?.id as Snowflake, categories[selectedCategory], selectedItems as string[]);
 					await interaction.followUp({
 						content: await client.bulbutils.translate("config_automod_add_remove_remove_success", interaction.guild?.id, {}),
 						ephemeral: true,
@@ -117,7 +117,7 @@ async function add(interaction: MessageComponentInteraction, client: BulbBotClie
 
 					msgCollector?.on("collect", async (m: Message) => {
 						await m.delete();
-						if (config[selectedCategory!].includes(m.content)) {
+						if (selectedCategory && config[selectedCategory].includes(m.content)) {
 							await interaction.followUp({
 								content: await client.bulbutils.translate("config_automod_add_remove_add_already_exists", interaction.guild?.id, {
 									item: m.content,
@@ -127,7 +127,7 @@ async function add(interaction: MessageComponentInteraction, client: BulbBotClie
 							return add(i, client, selectedCategory);
 						}
 
-						await databaseManager.automodAppend(interaction.guild?.id as Snowflake, categories[selectedCategory!], [m.content]);
+						if (selectedCategory) await databaseManager.automodAppend(interaction.guild?.id as Snowflake, categories[selectedCategory], [m.content]);
 
 						await interaction.followUp({
 							content: await client.bulbutils.translate("config_automod_add_remove_add_success", interaction.guild?.id, {}),

--- a/src/commands/Configuration/configure/automod/enable.ts
+++ b/src/commands/Configuration/configure/automod/enable.ts
@@ -70,7 +70,7 @@ async function enable(interaction: MessageComponentInteraction, client: BulbBotC
 
 						await enable(i, client);
 					} else {
-						await databaseManager.automodSetPunishment(interaction.guild?.id as Snowflake, parts[selectedCategory!], null);
+						await databaseManager.automodSetPunishment(interaction.guild?.id as Snowflake, parts[selectedCategory], null);
 						await interaction.followUp({
 							content: await client.bulbutils.translate("config_enable_disable_disable_success", interaction.guild?.id, {}),
 							ephemeral: true,

--- a/src/commands/Configuration/configure/automod/limit.ts
+++ b/src/commands/Configuration/configure/automod/limit.ts
@@ -99,8 +99,8 @@ async function limit(interaction: MessageComponentInteraction, client: BulbBotCl
 						return limit(i, client, category);
 					}
 
-					await databaseManager.automodSetLimit(interaction.guild?.id as Snowflake, parts[category!], parseInt(items));
-					await databaseManager.automodSetTimeout(interaction.guild?.id as Snowflake, parts[category!], parseInt(seconds) * 1000);
+					if (category !== undefined) await databaseManager.automodSetLimit(interaction.guild?.id as Snowflake, parts[category], parseInt(items));
+					if (category !== undefined) await databaseManager.automodSetTimeout(interaction.guild?.id as Snowflake, parts[category], parseInt(seconds) * 1000);
 					await interaction.followUp({ content: `Updated to ${items}/${seconds}`, ephemeral: true });
 
 					return limit(i, client, category);

--- a/src/commands/Configuration/configure/automod/limit.ts
+++ b/src/commands/Configuration/configure/automod/limit.ts
@@ -35,10 +35,10 @@ async function limit(interaction: MessageComponentInteraction, client: BulbBotCl
 	collector?.on("collect", async (i: MessageComponentInteraction) => {
 		if (i.isButton()) {
 			if (i.customId === "back") {
-				collector?.stop();
+				collector.stop();
 				return require("../automod").default(i, client);
 			} else if (i.customId === "update") {
-				collector?.stop();
+				collector.stop();
 				const messageFilter = (m: Message) => m.author.id === interaction.user.id;
 				const messageCollector = interaction.channel?.createMessageCollector({ filter: messageFilter, time: 60000, max: 1 });
 				await interaction.followUp({
@@ -107,7 +107,7 @@ async function limit(interaction: MessageComponentInteraction, client: BulbBotCl
 				});
 			}
 		} else if (i.isSelectMenu()) {
-			collector?.stop();
+			collector.stop();
 			return limit(i, client, i.values[0]);
 		}
 	});

--- a/src/commands/Configuration/configure/automod/overview.ts
+++ b/src/commands/Configuration/configure/automod/overview.ts
@@ -8,7 +8,8 @@ import { embedColor } from "../../../../Config";
 const databaseManager: DatabaseManager = new DatabaseManager();
 
 async function overview(interaction: MessageComponentInteraction, client: BulbBotClient) {
-	const dbGuild: AutoModConfiguration = await databaseManager.getAutoModConfig(interaction.guild!.id);
+	if (!interaction.guild?.id) return;
+	const dbGuild: AutoModConfiguration = await databaseManager.getAutoModConfig(interaction.guild.id);
 
 	const roles: string[] = [];
 	const channels: string[] = [];
@@ -21,27 +22,27 @@ async function overview(interaction: MessageComponentInteraction, client: BulbBo
 	const description: string[] = [];
 
 	description.push(
-		await client.bulbutils.translate("automod_settings_enabled", interaction.guild?.id, {
+		await client.bulbutils.translate("automod_settings_enabled", interaction.guild.id, {
 			enabled: dbGuild.enabled ? Emotes.other.SWITCHON : Emotes.other.SWITCHOFF,
 		}),
 	);
 
 	description.push(
-		await client.bulbutils.translate("automod_settings_websites", interaction.guild?.id, {
+		await client.bulbutils.translate("automod_settings_websites", interaction.guild.id, {
 			enabled: dbGuild.punishmentWebsite !== null ? `\`${dbGuild.punishmentWebsite}\`` : Emotes.other.SWITCHOFF,
 			websites_blacklist: dbGuild.websiteWhitelist.length ? dbGuild.websiteWhitelist.map((web) => `\`${web}\``).join(" ") : "None",
 		}),
 	);
 
 	description.push(
-		await client.bulbutils.translate("automod_settings_invites", interaction.guild?.id, {
+		await client.bulbutils.translate("automod_settings_invites", interaction.guild.id, {
 			enabled: dbGuild.punishmentInvites !== null ? `\`${dbGuild.punishmentInvites}\`` : Emotes.other.SWITCHOFF,
 			invites_blacklist: dbGuild.inviteWhitelist.length ? dbGuild.inviteWhitelist.map((i) => `\`${i}\``).join(" ") : "None",
 		}),
 	);
 
 	description.push(
-		await client.bulbutils.translate("automod_settings_words", interaction.guild?.id, {
+		await client.bulbutils.translate("automod_settings_words", interaction.guild.id, {
 			enabled: dbGuild.punishmentWords !== null ? `\`${dbGuild.punishmentWords}\`` : Emotes.other.SWITCHOFF,
 			word_blacklist: dbGuild.wordBlacklist.length ? dbGuild.wordBlacklist.join(" ") : "None",
 			word_token_blacklist: dbGuild.wordBlacklistToken.length ? dbGuild.wordBlacklistToken.map((w) => `\`${w}\``).join(" ") : "None",
@@ -49,7 +50,7 @@ async function overview(interaction: MessageComponentInteraction, client: BulbBo
 	);
 
 	description.push(
-		await client.bulbutils.translate("automod_settings_mentions", interaction.guild?.id, {
+		await client.bulbutils.translate("automod_settings_mentions", interaction.guild.id, {
 			enabled: dbGuild.punishmentMentions ? `\`${dbGuild.punishmentMentions}\`` : Emotes.other.SWITCHOFF,
 			limit: dbGuild.limitMentions,
 			timeout: dbGuild.timeoutMentions / 1000,
@@ -57,7 +58,7 @@ async function overview(interaction: MessageComponentInteraction, client: BulbBo
 	);
 
 	description.push(
-		await client.bulbutils.translate("automod_settings_messages", interaction.guild?.id, {
+		await client.bulbutils.translate("automod_settings_messages", interaction.guild.id, {
 			enabled: dbGuild.punishmentMessages ? `\`${dbGuild.punishmentMessages}\`` : Emotes.other.SWITCHOFF,
 			limit: dbGuild.limitMessages,
 			timeout: dbGuild.timeoutMessages / 1000,
@@ -65,14 +66,14 @@ async function overview(interaction: MessageComponentInteraction, client: BulbBo
 	);
 
 	description.push(
-		await client.bulbutils.translate("automod_settings_avatarbans", interaction.guild?.id, {
+		await client.bulbutils.translate("automod_settings_avatarbans", interaction.guild.id, {
 			enabled: dbGuild.punishmentAvatarBans !== null ? `\`${dbGuild.punishmentAvatarBans}\`` : Emotes.other.SWITCHOFF,
 			avatar_blacklist: dbGuild.avatarHashes.length ? dbGuild.avatarHashes.map((h) => `\`${h}\``).join(" ") : "None",
 		}),
 	);
 
 	description.push(
-		await client.bulbutils.translate("automod_settings_ignored", interaction.guild?.id, {
+		await client.bulbutils.translate("automod_settings_ignored", interaction.guild.id, {
 			roles: roles.join(" "),
 			channels: channels.join(" "),
 			users: users.join(" "),
@@ -82,24 +83,24 @@ async function overview(interaction: MessageComponentInteraction, client: BulbBo
 	const embed: MessageEmbed = new MessageEmbed()
 		.setColor(embedColor)
 		.setAuthor({
-			name: await client.bulbutils.translate("automod_settings_header", interaction.guild?.id, { guild: interaction.guild }),
-			iconURL: interaction.guild!.iconURL({ dynamic: true }) ?? undefined,
+			name: await client.bulbutils.translate("automod_settings_header", interaction.guild.id, { guild: interaction.guild }),
+			iconURL: interaction.guild.iconURL({ dynamic: true }) ?? undefined,
 		})
 		.setDescription(description.join("\n\n"))
 		.setFooter({
-			text: await client.bulbutils.translate("automod_settings_footer", interaction.guild?.id, {}),
+			text: await client.bulbutils.translate("automod_settings_footer", interaction.guild.id, {}),
 			iconURL: "https://cdn.discordapp.com/emojis/833770837575860305.png?v=1",
 		});
 
 	const buttonRow = new MessageActionRow().setComponents(
 		new MessageButton()
 			.setCustomId("back")
-			.setLabel(await client.bulbutils.translate("config_button_back", interaction.guild?.id, {}))
+			.setLabel(await client.bulbutils.translate("config_button_back", interaction.guild.id, {}))
 			.setStyle("DANGER"),
 	);
 
 	await interaction.update({
-		content: await client.bulbutils.translate("config_automod_overview_header", interaction.guild?.id, {}),
+		content: await client.bulbutils.translate("config_automod_overview_header", interaction.guild.id, {}),
 		embeds: [embed],
 		components: [buttonRow],
 	});

--- a/src/commands/Configuration/configure/automod/punishment.ts
+++ b/src/commands/Configuration/configure/automod/punishment.ts
@@ -87,7 +87,7 @@ async function punishment(interaction: MessageComponentInteraction, client: Bulb
 				return punishment(i, client, i.values[0]);
 			} else if (i.customId === "punishment") {
 				collector.stop();
-				await databaseManager.automodSetPunishment(interaction.guild?.id as Snowflake, categories[selectedCategory!], punishmentTypes[i.values[0]]);
+				selectedCategory && (await databaseManager.automodSetPunishment(interaction.guild?.id as Snowflake, categories[selectedCategory], punishmentTypes[i.values[0]]));
 				return punishment(i, client, selectedCategory);
 			}
 		}

--- a/src/commands/Configuration/messageclear.ts
+++ b/src/commands/Configuration/messageclear.ts
@@ -34,16 +34,18 @@ export default class extends Command {
 		if (days < 0) return context.channel.send(await this.client.bulbutils.translate("messageclear_few_than_0days", context.guild?.id, {}));
 		if (days > 30) return context.channel.send(await this.client.bulbutils.translate("messageclear_more_than_30days", context.guild?.id, {}));
 
-		const amountOfMessages = (await getServerArchive(context.guild!.id, days.toString())).length;
+		if (!context.guild?.id) return context.channel.send(await this.client.bulbutils.translate("global_error.unknown", context.guild?.id, {}));
+
+		const amountOfMessages = (await getServerArchive(context.guild.id, days.toString())).length;
 		const row = new MessageActionRow().addComponents([
 			new MessageButton().setStyle("SUCCESS").setLabel("Confirm").setCustomId("confirm"),
 			new MessageButton().setStyle("DANGER").setLabel("Cancel").setCustomId("cancel"),
 		]);
 
-		if (amountOfMessages === 0) return context.channel.send(await this.client.bulbutils.translate("messageclear_found_no_message", context.guild?.id, {}));
+		if (amountOfMessages === 0) return context.channel.send(await this.client.bulbutils.translate("messageclear_found_no_message", context.guild.id, {}));
 
 		const confirmMsg = await context.channel.send({
-			content: await this.client.bulbutils.translate("messageclear_about_to_clear", context.guild?.id, {
+			content: await this.client.bulbutils.translate("messageclear_about_to_clear", context.guild.id, {
 				messages: amountOfMessages,
 			}),
 			components: [row],
@@ -58,7 +60,7 @@ export default class extends Command {
 
 			if (interaction.customId === "confirm") {
 				collector.stop("clicked");
-				await purgeMessagesInGuild(context.guild!.id, days.toString());
+				if (context.guild?.id) await purgeMessagesInGuild(context.guild.id, days.toString());
 
 				return await interaction.update({
 					content: await this.client.bulbutils.translate("messageclear_success_delete", context.guild?.id, { messages: amountOfMessages }),

--- a/src/commands/Configuration/override/create.ts
+++ b/src/commands/Configuration/override/create.ts
@@ -1,5 +1,5 @@
 import { NonDigits } from "../../../utils/Regex";
-import { ButtonInteraction, Message, MessageActionRow, MessageButton, Snowflake } from "discord.js";
+import { ButtonInteraction, Message, MessageActionRow, MessageButton } from "discord.js";
 import ClearanceManager from "../../../utils/managers/ClearanceManager";
 import Command from "../../../structures/Command";
 import SubCommand from "../../../structures/SubCommand";
@@ -39,7 +39,7 @@ export default class extends SubCommand {
 
 		switch (part) {
 			case "role":
-				if ((await clearanceManager.getCommandOverride(<Snowflake>context.guild?.id, name[0])) !== undefined)
+				if ((await clearanceManager.getCommandOverride(context.guild?.id, name[0])) !== undefined)
 					return await context.channel.send(await this.client.bulbutils.translate("override_already_exists", context.guild?.id, {}));
 				const rTemp = context.guild?.roles.cache.get(name[0].replace(NonDigits, ""));
 				if (rTemp === undefined)
@@ -52,7 +52,7 @@ export default class extends SubCommand {
 						}),
 					);
 
-				await clearanceManager.createRoleOverride(<Snowflake>context.guild?.id, name[0].replace(NonDigits, ""), clearance);
+				await clearanceManager.createRoleOverride(context.guild?.id, name[0].replace(NonDigits, ""), clearance);
 				await context.channel.send(await this.client.bulbutils.translate("override_create_success", context.guild?.id, { clearance }));
 				break;
 			case "command":
@@ -68,7 +68,7 @@ export default class extends SubCommand {
 						}),
 					);
 
-				if ((await clearanceManager.getCommandOverride(<Snowflake>context.guild?.id, command.qualifiedName)) !== undefined)
+				if ((await clearanceManager.getCommandOverride(context.guild?.id, command.qualifiedName)) !== undefined)
 					return await context.channel.send(await this.client.bulbutils.translate("override_already_exists", context.guild?.id, {}));
 
 				if (clearance === 0 && (command.category === "Moderation" || command.category === "Configuration")) {
@@ -96,7 +96,7 @@ export default class extends SubCommand {
 						if (interaction.customId === "confirm") {
 							await interaction.update({ content: await this.client.bulbutils.translate("override_create_success", context.guild?.id, { clearance }), components: [] });
 							collector.stop("clicked");
-							return clearanceManager.createCommandOverride(<Snowflake>context.guild?.id, command.qualifiedName, true, clearance);
+							return clearanceManager.createCommandOverride(context.guild?.id, command.qualifiedName, true, clearance);
 						} else {
 							collector.stop("clicked");
 							return interaction.update({ content: await this.client.bulbutils.translate("global_execution_cancel", context.guild?.id, {}), components: [] });
@@ -110,7 +110,7 @@ export default class extends SubCommand {
 						return;
 					});
 				} else {
-					await clearanceManager.createCommandOverride(<Snowflake>context.guild?.id, command.qualifiedName, true, clearance);
+					await clearanceManager.createCommandOverride(context.guild?.id, command.qualifiedName, true, clearance);
 					await context.channel.send(await this.client.bulbutils.translate("override_create_success", context.guild?.id, { clearance }));
 				}
 				break;

--- a/src/commands/Configuration/override/delete.ts
+++ b/src/commands/Configuration/override/delete.ts
@@ -1,5 +1,5 @@
 import { NonDigits } from "../../../utils/Regex";
-import { Message, Snowflake } from "discord.js";
+import { Message } from "discord.js";
 import ClearanceManager from "../../../utils/managers/ClearanceManager";
 import Command from "../../../structures/Command";
 import SubCommand from "../../../structures/SubCommand";
@@ -27,19 +27,19 @@ export default class extends SubCommand {
 		switch (part) {
 			case "role": {
 				const name = args[1];
-				if (!(await clearanceManager.getRoleOverride(<Snowflake>context.guild?.id, name.replace(NonDigits, ""))))
+				if (!(await clearanceManager.getRoleOverride(context.guild?.id, name.replace(NonDigits, ""))))
 					return context.channel.send(await this.client.bulbutils.translate("override_nonexistent_role", context.guild?.id, { role: name }));
 
-				await clearanceManager.deleteRoleOverride(<Snowflake>context.guild?.id, name.replace(NonDigits, ""));
+				await clearanceManager.deleteRoleOverride(context.guild?.id, name.replace(NonDigits, ""));
 				break;
 			}
 			case "command": {
 				const name = args.slice(1);
 				const command = Command.resolve(this.client, name);
-				if (!command || command.name === undefined || !(await clearanceManager.getCommandOverride(<Snowflake>context.guild?.id, command.qualifiedName)))
+				if (!command || command.name === undefined || !(await clearanceManager.getCommandOverride(context.guild?.id, command.qualifiedName)))
 					return context.channel.send(await this.client.bulbutils.translate("override_nonexistent_command", context.guild?.id, { command: name.join(" ") }));
 
-				await clearanceManager.deleteCommandOverride(<Snowflake>context.guild?.id, command.qualifiedName);
+				await clearanceManager.deleteCommandOverride(context.guild?.id, command.qualifiedName);
 				break;
 			}
 			default:

--- a/src/commands/Configuration/override/disable.ts
+++ b/src/commands/Configuration/override/disable.ts
@@ -1,4 +1,4 @@
-import { Message, Snowflake } from "discord.js";
+import { Message } from "discord.js";
 import ClearanceManager from "../../../utils/managers/ClearanceManager";
 import Command from "../../../structures/Command";
 import SubCommand from "../../../structures/SubCommand";
@@ -31,10 +31,10 @@ export default class extends SubCommand {
 				}),
 			);
 
-		if ((await clearanceManager.getCommandOverride(<Snowflake>context.guild?.id, command.qualifiedName)) !== undefined) {
-			await clearanceManager.setEnabled(<Snowflake>context.guild?.id, command.qualifiedName, false);
+		if ((await clearanceManager.getCommandOverride(context.guild?.id, command.qualifiedName)) !== undefined) {
+			await clearanceManager.setEnabled(context.guild?.id, command.qualifiedName, false);
 		} else {
-			await clearanceManager.createCommandOverride(<Snowflake>context.guild?.id, command.qualifiedName, false, command.clearance);
+			await clearanceManager.createCommandOverride(context.guild?.id, command.qualifiedName, false, command.clearance);
 		}
 
 		await context.channel.send(await this.client.bulbutils.translate("override_disable_success", context.guild?.id, { command: command.qualifiedName }));

--- a/src/commands/Configuration/override/edit.ts
+++ b/src/commands/Configuration/override/edit.ts
@@ -1,5 +1,5 @@
 import { NonDigits } from "../../../utils/Regex";
-import { ButtonInteraction, Message, MessageActionRow, MessageButton, Snowflake } from "discord.js";
+import { ButtonInteraction, Message, MessageActionRow, MessageButton } from "discord.js";
 import ClearanceManager from "../../../utils/managers/ClearanceManager";
 import Command from "../../../structures/Command";
 import SubCommand from "../../../structures/SubCommand";
@@ -52,9 +52,9 @@ export default class extends SubCommand {
 						}),
 					);
 
-				if ((await clearanceManager.getRoleOverride(<Snowflake>context.guild?.id, rTemp.id)) === undefined)
+				if ((await clearanceManager.getRoleOverride(context.guild?.id, rTemp.id)) === undefined)
 					return context.channel.send(await this.client.bulbutils.translate("override_nonexistent_role", context.guild?.id, { role: rTemp.name }));
-				await clearanceManager.editRoleOverride(<Snowflake>context.guild?.id, roleID, clearance);
+				await clearanceManager.editRoleOverride(context.guild?.id, roleID, clearance);
 				await context.channel.send(await this.client.bulbutils.translate("override_edit_success", context.guild?.id, { clearance }));
 				break;
 			}
@@ -71,7 +71,7 @@ export default class extends SubCommand {
 						}),
 					);
 
-				if ((await clearanceManager.getCommandOverride(<Snowflake>context.guild?.id, command.qualifiedName)) === undefined)
+				if ((await clearanceManager.getCommandOverride(context.guild?.id, command.qualifiedName)) === undefined)
 					return context.channel.send(
 						await this.client.bulbutils.translate("override_nonexistent_command", context.guild?.id, {
 							command: command.qualifiedName,
@@ -103,7 +103,7 @@ export default class extends SubCommand {
 						if (interaction.customId === "confirm") {
 							await interaction.update({ content: await this.client.bulbutils.translate("override_edit_success", context.guild?.id, { clearance }), components: [] });
 							collector.stop("clicked");
-							return clearanceManager.createCommandOverride(<Snowflake>context.guild?.id, command.qualifiedName, true, clearance);
+							return clearanceManager.createCommandOverride(context.guild?.id, command.qualifiedName, true, clearance);
 						} else {
 							collector.stop("clicked");
 							return interaction.update({ content: await this.client.bulbutils.translate("global_execution_cancel", context.guild?.id, {}), components: [] });
@@ -117,7 +117,7 @@ export default class extends SubCommand {
 						return;
 					});
 				} else {
-					await clearanceManager.editCommandOverride(<Snowflake>context.guild?.id, command.qualifiedName, clearance);
+					await clearanceManager.editCommandOverride(context.guild?.id, command.qualifiedName, clearance);
 					await context.channel.send(await this.client.bulbutils.translate("override_edit_success", context.guild?.id, { clearance }));
 				}
 				break;

--- a/src/commands/Configuration/override/enable.ts
+++ b/src/commands/Configuration/override/enable.ts
@@ -1,4 +1,4 @@
-import { Message, Snowflake } from "discord.js";
+import { Message } from "discord.js";
 import ClearanceManager from "../../../utils/managers/ClearanceManager";
 import Command from "../../../structures/Command";
 import SubCommand from "../../../structures/SubCommand";
@@ -31,8 +31,8 @@ export default class extends SubCommand {
 				}),
 			);
 
-		if ((await clearanceManager.getCommandOverride(<Snowflake>context.guild?.id, command.qualifiedName)) !== undefined) {
-			await clearanceManager.setEnabled(<Snowflake>context.guild?.id, command.qualifiedName, true);
+		if ((await clearanceManager.getCommandOverride(context.guild?.id, command.qualifiedName)) !== undefined) {
+			await clearanceManager.setEnabled(context.guild?.id, command.qualifiedName, true);
 		} else {
 			return context.channel.send(await this.client.bulbutils.translate("override_nonexistent_command", context.guild?.id, { command: command.qualifiedName }));
 		}

--- a/src/commands/Configuration/override/list.ts
+++ b/src/commands/Configuration/override/list.ts
@@ -1,4 +1,4 @@
-import { Message, MessageEmbed, Snowflake } from "discord.js";
+import { Message, MessageEmbed } from "discord.js";
 import { embedColor } from "../../../Config";
 import * as Emotes from "../../../emotes.json";
 import BulbBotClient from "../../../structures/BulbBotClient";
@@ -20,7 +20,8 @@ export default class extends SubCommand {
 	}
 
 	async run(context: CommandContext): Promise<void | Message> {
-		const data: Record<string, any> = await clearanceManager.getClearanceList(<Snowflake>context.guild?.id);
+		const data = await clearanceManager.getClearanceList(context.guild?.id);
+		if (!data) return;
 
 		const roles: string[] = [];
 		const commands: string[] = [];

--- a/src/commands/Configuration/settings.ts
+++ b/src/commands/Configuration/settings.ts
@@ -61,12 +61,12 @@ export default class extends Command {
 		const embed = new MessageEmbed()
 			.setColor(Config.embedColor)
 			.setAuthor({
-				name: `Settings for ${context.guild?.name}`,
+				name: `Settings for ${context.guild.name}`,
 				iconURL: context.guild.iconURL({ dynamic: true }) ?? undefined,
 			})
 			.setDescription(`${configs.join("\n")}\n\n${loggingModule.join("\n")}`)
 			.setFooter({
-				text: await this.client.bulbutils.translate("global_executed_by", context.guild?.id, { user: context.author }),
+				text: await this.client.bulbutils.translate("global_executed_by", context.guild.id, { user: context.author }),
 				iconURL: memberObj?.avatarUrl ?? "",
 			})
 			.setTimestamp();

--- a/src/commands/Configuration/settings.ts
+++ b/src/commands/Configuration/settings.ts
@@ -22,8 +22,12 @@ export default class extends Command {
 	}
 
 	async run(context: CommandContext) {
-		const guildConfig: GuildConfiguration = await databaseManager.getConfig(context.guild!.id);
-		const loggingConfig: LoggingConfiguration = await databaseManager.getLoggingConfig(context.guild!.id);
+		if (!context.guild?.id) {
+			console.error("Guild/GuildID is not defined (in commands/Configuration/settings)");
+			return;
+		}
+		const guildConfig: GuildConfiguration = await databaseManager.getConfig(context.guild.id);
+		const loggingConfig: LoggingConfiguration = await databaseManager.getLoggingConfig(context.guild.id);
 
 		const configs: string[] = [
 			`**Configuration**`,
@@ -52,18 +56,18 @@ export default class extends Command {
 			`Other: ${loggingConfig.other !== null ? `<#${loggingConfig.other}>` : Emotes.other.SWITCHOFF}`,
 		];
 
-		const memberObj = await this.client.bulbutils.userObject(true, context.member!);
+		const memberObj = this.client.bulbutils.userObject(true, context.member);
 
 		const embed = new MessageEmbed()
 			.setColor(Config.embedColor)
 			.setAuthor({
-				name: `Settings for ${context.guild!.name}`,
-				iconURL: context.guild?.iconURL({ dynamic: true }) ?? undefined,
+				name: `Settings for ${context.guild?.name}`,
+				iconURL: context.guild.iconURL({ dynamic: true }) ?? undefined,
 			})
 			.setDescription(`${configs.join("\n")}\n\n${loggingModule.join("\n")}`)
 			.setFooter({
-				text: await this.client.bulbutils.translate("global_executed_by", context.guild!.id, { user: context.author }),
-				iconURL: memberObj.avatarUrl,
+				text: await this.client.bulbutils.translate("global_executed_by", context.guild?.id, { user: context.author }),
+				iconURL: memberObj?.avatarUrl ?? "",
 			})
 			.setTimestamp();
 

--- a/src/commands/Information/channelinfo.ts
+++ b/src/commands/Information/channelinfo.ts
@@ -83,7 +83,7 @@ export default class extends Command {
 				text: await this.client.bulbutils.translate("global_executed_by", context.guild?.id, {
 					user: context.author,
 				}),
-				iconURL: <string>context.author.avatarURL({ dynamic: true }),
+				iconURL: context.author.avatarURL({ dynamic: true }) || "",
 			})
 			.setTimestamp();
 

--- a/src/commands/Information/channelinfo.ts
+++ b/src/commands/Information/channelinfo.ts
@@ -2,8 +2,9 @@ import Command from "../../structures/Command";
 import CommandContext from "../../structures/CommandContext";
 import BulbBotClient from "../../structures/BulbBotClient";
 import { NonDigits } from "../../utils/Regex";
-import { GuildChannel, MessageActionRow, MessageButton, MessageEmbed, TextChannel, ThreadChannel } from "discord.js";
+import { MessageActionRow, MessageButton, MessageEmbed } from "discord.js";
 import { embedColor } from "../../Config";
+import { isTextChannel } from "../../utils/typechecks";
 
 export default class extends Command {
 	constructor(client: BulbBotClient, name: string) {
@@ -25,11 +26,11 @@ export default class extends Command {
 		if (args[0] === undefined) channelId = context.channel.id;
 		else channelId = args[0].replace(NonDigits, "");
 
-		const channel: GuildChannel | ThreadChannel | undefined = context.guild?.channels.cache.get(channelId);
-		if (!channel?.permissionsFor(context.member!)?.has("VIEW_CHANNEL", true)) {
+		const channel = context.guild?.channels.cache.get(channelId);
+		if (!(context.member && channel?.permissionsFor(context.member)?.has("VIEW_CHANNEL", true))) {
 			context.channel.send(
-				await this.client.bulbutils.translate("global_not_found", context.guild!.id, {
-					type: await this.client.bulbutils.translate("global_not_found_types.channel", context.guild!.id, {}),
+				await this.client.bulbutils.translate("global_not_found", context.guild?.id, {
+					type: await this.client.bulbutils.translate("global_not_found_types.channel", context.guild?.id, {}),
 					arg_expected: "channel:Channel",
 					arg_provided: args[0],
 					usage: this.usage,
@@ -41,24 +42,21 @@ export default class extends Command {
 		channel.parentId !== null ? desc.push(`**Parent:** ${channel.parent?.name}`) : "";
 		const buttons: MessageButton[] = [];
 
-		if (channel.isText()) {
+		if (isTextChannel(channel)) {
 			channel.lastMessageId !== null
 				? buttons.push(new MessageButton().setStyle("LINK").setLabel("Latest message").setURL(`https://discord.com/channels/${context.guild?.id}/${channel.id}/${channel.lastMessageId}`))
 				: null;
 
-			channel.rateLimitPerUser! > 0 ? desc.push(`**Slowmode:** ${channel.rateLimitPerUser} seconds`) : null;
-			if (channel.type !== "GUILD_NEWS_THREAD" && channel.type !== "GUILD_PRIVATE_THREAD" && channel.type !== "GUILD_PUBLIC_THREAD") {
-				const textChannels: TextChannel = <TextChannel>(<unknown>channel);
-				textChannels.topic !== null ? desc.push(`**Topic:** ${textChannels.topic}`) : null;
-				desc.push(`**NSFW:** ${textChannels.nsfw}`);
-				desc.push(
-					`\n**Your permissions:** ${textChannels
-						.permissionsFor(context.author)
-						?.toArray()
-						.map((p) => `\`${p}\``)
-						.join(" ")}`,
-				);
-			}
+			channel.rateLimitPerUser > 0 ? desc.push(`**Slowmode:** ${channel.rateLimitPerUser} seconds`) : null;
+			channel.topic !== null ? desc.push(`**Topic:** ${channel.topic}`) : null;
+			desc.push(`**NSFW:** ${channel.nsfw}`);
+			desc.push(
+				`\n**Your permissions:** ${channel
+					.permissionsFor(context.author)
+					?.toArray()
+					.map((p) => `\`${p}\``)
+					.join(" ")}`,
+			);
 		} else if (channel.isVoice()) {
 			desc.push(`**RTC region:** ${channel.rtcRegion === null ? "Automatic" : channel.rtcRegion}`);
 			desc.push(`**User limit:** ${channel.userLimit === 0 ? "Unlimited" : channel.userLimit}`);

--- a/src/commands/Information/inviteinfo.ts
+++ b/src/commands/Information/inviteinfo.ts
@@ -23,21 +23,21 @@ export default class extends Command {
 
 	async run(context: CommandContext, args: string[]): Promise<void> {
 		const code: string = args[0];
-		let invite!: Invite;
+		let invite: Invite;
 
 		try {
 			invite = await this.client.fetchInvite(code);
 		} catch (error) {
-			await context.channel.send(await this.client.bulbutils.translate("inviteinfo_error", context.guild!.id, {}));
+			await context.channel.send(await this.client.bulbutils.translate("inviteinfo_error", context.guild?.id, {}));
 			return;
 		}
 
 		if (invite.channel.type === "GROUP_DM") {
-			context.channel.send(await this.client.bulbutils.translate("inviteinfo_groupdm", context.guild!.id, {}));
+			context.channel.send(await this.client.bulbutils.translate("inviteinfo_groupdm", context.guild?.id, {}));
 			return;
 		}
 
-		const guild = invite!.guild;
+		const guild = invite.guild;
 		if (guild === null || context.guild === null || context.member === null) return;
 
 		let desc = "";
@@ -73,20 +73,20 @@ export default class extends Command {
 		const embeds: MessageEmbed[] = [];
 		const embed = new MessageEmbed()
 			.setColor(embedColor)
-			.setTitle(guild.description !== null ? `${guild.description}` : "")
+			.setTitle(guild.description || "")
 			.setAuthor({
 				name: `${guild.name} (${guild.id})`,
 				iconURL: guild.iconURL({ dynamic: true }) ?? undefined,
 			})
 			.setDescription(desc)
 			.addField("**Invite**", inviteInfo, true)
-			.setThumbnail(guild.iconURL({ dynamic: true, size: 4096 })!)
+			.setThumbnail(guild.iconURL({ dynamic: true, size: 4096 }) || "")
 			.setImage(guild.splash !== null ? `https://cdn.discordapp.com/splashes/${guild.id}/${guild.splash}.png?size=4096` : "")
 			.setFooter({
 				text: await this.client.bulbutils.translate("global_executed_by", context.guild.id, {
 					user: context.author,
 				}),
-				iconURL: await this.client.bulbutils.userObject(true, context.member).avatarUrl,
+				iconURL: this.client.bulbutils.userObject(true, context.member)?.avatarUrl ?? undefined,
 			})
 			.setTimestamp();
 		embeds.push(embed);
@@ -106,7 +106,7 @@ export default class extends Command {
 					text: await this.client.bulbutils.translate("global_executed_by", context.guild.id, {
 						user: context.author,
 					}),
-					iconURL: await this.client.bulbutils.userObject(true, context.member).avatarUrl,
+					iconURL: this.client.bulbutils.userObject(true, context.member)?.avatarUrl ?? undefined,
 				})
 				.setTimestamp()
 				.setDescription(`**Member (${widget.members.size})**\n${widget.members.map((m) => `\`${m.username}\``).join(" ")}`);

--- a/src/commands/Information/messageinfo.ts
+++ b/src/commands/Information/messageinfo.ts
@@ -91,7 +91,7 @@ export default class extends Command {
 				text: await this.client.bulbutils.translate("global_executed_by", context.guild?.id, {
 					user: context.author,
 				}),
-				iconURL: <string>context.author.avatarURL({ dynamic: true }),
+				iconURL: context.author.avatarURL({ dynamic: true }) || "",
 			})
 			.setTimestamp();
 

--- a/src/commands/Information/messageinfo.ts
+++ b/src/commands/Information/messageinfo.ts
@@ -43,7 +43,7 @@ export default class extends Command {
 		}
 
 		const channel = context.guild?.channels.cache.get(channelId);
-		if (!channel || !context.member || (channel?.type !== "GUILD_TEXT" && channel?.type !== "GUILD_NEWS" && !channel?.permissionsFor(context.member)?.has("VIEW_CHANNEL", true))) {
+		if (!channel || !context.member || (channel.type !== "GUILD_TEXT" && channel.type !== "GUILD_NEWS" && !channel.permissionsFor(context.member).has("VIEW_CHANNEL", true))) {
 			context.channel.send(
 				await this.client.bulbutils.translate("global_not_found", context.guild?.id, {
 					type: await this.client.bulbutils.translate("global_not_found_types.message", context.guild?.id, {}),

--- a/src/commands/Information/messageinfo.ts
+++ b/src/commands/Information/messageinfo.ts
@@ -43,10 +43,10 @@ export default class extends Command {
 		}
 
 		const channel = context.guild?.channels.cache.get(channelId);
-		if (channel?.type !== "GUILD_TEXT" && channel?.type !== "GUILD_NEWS" && !channel?.permissionsFor(context.member!)?.has("VIEW_CHANNEL", true)) {
+		if (!channel || !context.member || (channel?.type !== "GUILD_TEXT" && channel?.type !== "GUILD_NEWS" && !channel?.permissionsFor(context.member)?.has("VIEW_CHANNEL", true))) {
 			context.channel.send(
-				await this.client.bulbutils.translate("global_not_found", context.guild!.id, {
-					type: await this.client.bulbutils.translate("global_not_found_types.message", context.guild!.id, {}),
+				await this.client.bulbutils.translate("global_not_found", context.guild?.id, {
+					type: await this.client.bulbutils.translate("global_not_found_types.message", context.guild?.id, {}),
 					arg_expected: "message:Message",
 					arg_provided: args[0],
 					usage: this.usage,
@@ -60,8 +60,8 @@ export default class extends Command {
 			message = await channel.messages.fetch(messageId);
 		} catch (error) {
 			context.channel.send(
-				await this.client.bulbutils.translate("global_not_found", context.guild!.id, {
-					type: await this.client.bulbutils.translate("global_not_found_types.message", context.guild!.id, {}),
+				await this.client.bulbutils.translate("global_not_found", context.guild?.id, {
+					type: await this.client.bulbutils.translate("global_not_found_types.message", context.guild?.id, {}),
 					arg_expected: "message:Message",
 					arg_provided: args[0],
 					usage: this.usage,

--- a/src/commands/Information/roleinfo.ts
+++ b/src/commands/Information/roleinfo.ts
@@ -64,7 +64,7 @@ export default class extends Command {
 				text: await this.client.bulbutils.translate("global_executed_by", context.guild?.id, {
 					user: context.author,
 				}),
-				iconURL: <string>context.author.avatarURL({ dynamic: true }),
+				iconURL: context.author.avatarURL({ dynamic: true }) || "",
 			})
 			.setTimestamp();
 

--- a/src/commands/Information/server.ts
+++ b/src/commands/Information/server.ts
@@ -112,7 +112,7 @@ export default class extends Command {
 				text: await this.client.bulbutils.translate("global_executed_by", guild.id, {
 					user: context.author,
 				}),
-				iconURL: <string>context.author.avatarURL({ dynamic: true }),
+				iconURL: context.author.avatarURL({ dynamic: true }) || "",
 			})
 			.setTimestamp();
 

--- a/src/commands/Information/userinfo.ts
+++ b/src/commands/Information/userinfo.ts
@@ -1,6 +1,6 @@
 import Command from "../../structures/Command";
 import CommandContext, { getCommandContext } from "../../structures/CommandContext";
-import { ButtonInteraction, GuildMember, Message, MessageActionRow, MessageButton, MessageEmbed, Snowflake, User } from "discord.js";
+import { ButtonInteraction, GuildMember, Message, MessageActionRow, MessageButton, MessageEmbed, User } from "discord.js";
 import axios from "axios";
 import { NonDigits } from "../../utils/Regex";
 import InfractionsManager from "../../utils/managers/InfractionsManager";
@@ -32,6 +32,7 @@ export default class extends Command {
 	}
 
 	async run(context: CommandContext, args: string[]): Promise<void | Message> {
+		if (!context.guild) return;
 		let target: string;
 		if (args[0] === undefined) target = context.author.id;
 		else target = args[0].replace(NonDigits, "");
@@ -65,7 +66,7 @@ export default class extends Command {
 		]);
 
 		let components: MessageActionRow[];
-		const actionsOnInfo: boolean = (await databaseManager.getConfig(<Snowflake>context.guild?.id)).actionsOnInfo;
+		const actionsOnInfo: boolean = (await databaseManager.getConfig(context.guild.id)).actionsOnInfo;
 
 		if (!actionsOnInfo) components = [];
 		else if (!isGuildMember) components = [];
@@ -140,7 +141,7 @@ export default class extends Command {
 				}
 			}
 
-			const infs = await infractionsManager.getOffenderInfractions(<string>context.guild?.id, user.id);
+			const infs = await infractionsManager.getOffenderInfractions(context.guild.id, user.id);
 			if (infs) {
 				let inf_emoji;
 
@@ -167,7 +168,7 @@ export default class extends Command {
 					text: await this.client.bulbutils.translate("global_executed_by", context.guild?.id, {
 						user: context.author,
 					}),
-					iconURL: <string>context.author.avatarURL({ dynamic: true }),
+					iconURL: context.author.avatarURL({ dynamic: true }) || "",
 				})
 				.setTimestamp();
 
@@ -199,7 +200,7 @@ export default class extends Command {
 				msg.edit({ components: [rowDisabled] });
 				await interaction.reply({
 					content: await this.client.bulbutils.translate("userinfo_interaction_confirm", context.guild?.id, {
-						action: await this.client.bulbutils.translate(`mod_action_types.${<ButtonActionType>interaction.customId}`, context.guild?.id, {}),
+						action: await this.client.bulbutils.translate(`mod_action_types.${interaction.customId as ButtonActionType}`, context.guild?.id, {}),
 						target: user,
 					}),
 				});

--- a/src/commands/Information/userinfo.ts
+++ b/src/commands/Information/userinfo.ts
@@ -37,14 +37,14 @@ export default class extends Command {
 		if (args[0] === undefined) target = context.author.id;
 		else target = args[0].replace(NonDigits, "");
 
-		let user: Optional<User | GuildMember | UserObject> = await this.client.bulbfetch.getGuildMember(context.guild?.members, target);
+		let user: Optional<User | GuildMember | UserObject> = await this.client.bulbfetch.getGuildMember(context.guild.members, target);
 		const isGuildMember = true;
 
 		if (!user) user = await this.client.bulbfetch.getUser(target);
 		if (!user)
 			return await context.channel.send(
-				await this.client.bulbutils.translate("global_not_found", context.guild?.id, {
-					type: await this.client.bulbutils.translate("global_not_found_types.user", context.guild?.id, {}),
+				await this.client.bulbutils.translate("global_not_found", context.guild.id, {
+					type: await this.client.bulbutils.translate("global_not_found_types.user", context.guild.id, {}),
 					arg_expected: "user:User",
 					arg_provided: args[0],
 					usage: this.usage,
@@ -78,24 +78,24 @@ export default class extends Command {
 
 		if (user !== undefined && user) {
 			if (user.flags !== null) description += this.client.bulbutils.badges(user.flags.bitfield) + "\n";
-			description += await this.client.bulbutils.translate("userinfo_embed_id", context.guild?.id, { user });
-			description += await this.client.bulbutils.translate("userinfo_embed_username", context.guild?.id, { user });
-			if (user.nickname !== null && user.nickname) description += await this.client.bulbutils.translate("userinfo_embed_nickname", context.guild?.id, { user });
-			description += await this.client.bulbutils.translate("userinfo_embed_profile", context.guild?.id, { user });
-			description += await this.client.bulbutils.translate("userinfo_embed_avatar", context.guild?.id, { user });
-			description += await this.client.bulbutils.translate("userinfo_embed_bot", context.guild?.id, { user });
-			description += await this.client.bulbutils.translate("userinfo_embed_created", context.guild?.id, { user_age: Math.floor(user.createdTimestamp / 1000) });
+			description += await this.client.bulbutils.translate("userinfo_embed_id", context.guild.id, { user });
+			description += await this.client.bulbutils.translate("userinfo_embed_username", context.guild.id, { user });
+			if (user.nickname !== null && user.nickname) description += await this.client.bulbutils.translate("userinfo_embed_nickname", context.guild.id, { user });
+			description += await this.client.bulbutils.translate("userinfo_embed_profile", context.guild.id, { user });
+			description += await this.client.bulbutils.translate("userinfo_embed_avatar", context.guild.id, { user });
+			description += await this.client.bulbutils.translate("userinfo_embed_bot", context.guild.id, { user });
+			description += await this.client.bulbutils.translate("userinfo_embed_created", context.guild.id, { user_age: Math.floor(user.createdTimestamp / 1000) });
 
 			if (user.premiumSinceTimestamp !== undefined && user.premiumSinceTimestamp && user.premiumSinceTimestamp > 0)
-				description += await this.client.bulbutils.translate("userinfo_embed_premium", context.guild?.id, {
+				description += await this.client.bulbutils.translate("userinfo_embed_premium", context.guild.id, {
 					user_premium: Math.floor(user.premiumSinceTimestamp / 1000),
 				});
 
 			if (user.joinedTimestamp !== undefined && user.joinedTimestamp)
-				description += await this.client.bulbutils.translate("userinfo_embed_joined", context.guild?.id, { user_joined: Math.floor(user.joinedTimestamp / 1000) });
+				description += await this.client.bulbutils.translate("userinfo_embed_joined", context.guild.id, { user_joined: Math.floor(user.joinedTimestamp / 1000) });
 
 			if (user.roles !== undefined && user.roles)
-				description += await this.client.bulbutils.translate("userinfo_embed_roles", context.guild?.id, {
+				description += await this.client.bulbutils.translate("userinfo_embed_roles", context.guild.id, {
 					user_roles: user.roles.cache.map((r: any) => `${r}`).join(" "),
 				});
 
@@ -109,23 +109,23 @@ export default class extends Command {
 				}
 
 				if (data) {
-					description += await this.client.bulbutils.translate("userinfo_embed_bot_info", context.guild?.id, {});
+					description += await this.client.bulbutils.translate("userinfo_embed_bot_info", context.guild.id, {});
 					if (data.summary !== "") description += `\n> ${data.summary.split("\n").join(" ")}`;
-					if (data.tags) description += await this.client.bulbutils.translate("userinfo_embed_bot_tags", context.guild?.id, { tags: data.tags.map((t: any) => `\`${t}\``).join(" ") });
+					if (data.tags) description += await this.client.bulbutils.translate("userinfo_embed_bot_tags", context.guild.id, { tags: data.tags.map((t: any) => `\`${t}\``).join(" ") });
 
-					description += await this.client.bulbutils.translate("userinfo_embed_bot_public", context.guild?.id, { emoji: data.bot_public ? Emotes.other.SWITCHON : Emotes.other.SWITCHOFF });
-					description += await this.client.bulbutils.translate("userinfo_embed_bot_requires_code", context.guild?.id, {
+					description += await this.client.bulbutils.translate("userinfo_embed_bot_public", context.guild.id, { emoji: data.bot_public ? Emotes.other.SWITCHON : Emotes.other.SWITCHOFF });
+					description += await this.client.bulbutils.translate("userinfo_embed_bot_requires_code", context.guild.id, {
 						emoji: data.bot_require_code_grant ? Emotes.other.SWITCHON : Emotes.other.SWITCHOFF,
 					});
 					const botflags = this.client.bulbutils.applicationFlags(data.flags);
 
-					description += await this.client.bulbutils.translate("userinfo_embed_bot_presence_intent", context.guild?.id, {
+					description += await this.client.bulbutils.translate("userinfo_embed_bot_presence_intent", context.guild.id, {
 						emoji: botflags.includes("GATEWAY_PRESENCE") ? Emotes.other.SWITCHON : Emotes.other.SWITCHOFF,
 					});
-					description += await this.client.bulbutils.translate("userinfo_embed_server_memebers_intent", context.guild?.id, {
+					description += await this.client.bulbutils.translate("userinfo_embed_server_memebers_intent", context.guild.id, {
 						emoji: botflags.includes("GATEWAY_GUILD_MEMBERS") ? Emotes.other.SWITCHON : Emotes.other.SWITCHOFF,
 					});
-					description += await this.client.bulbutils.translate("userinfo_embed_bot_message_content_intent", context.guild?.id, {
+					description += await this.client.bulbutils.translate("userinfo_embed_bot_message_content_intent", context.guild.id, {
 						emoji: botflags.includes("GATEWAY_MESSAGE_CONTENT") ? Emotes.other.SWITCHON : Emotes.other.SWITCHOFF,
 					});
 
@@ -149,12 +149,12 @@ export default class extends Command {
 				else if (infs.length === 2) inf_emoji = Emotes.other.INF1;
 				else inf_emoji = Emotes.other.INF2;
 
-				description += await this.client.bulbutils.translate("userinfo_embed_infractions", context.guild?.id, { emote_inf: inf_emoji, user_infractions: infs.length });
+				description += await this.client.bulbutils.translate("userinfo_embed_infractions", context.guild.id, { emote_inf: inf_emoji, user_infractions: infs.length });
 			}
 
 			let color;
-			if (user.roles === undefined || user.roles?.highest.name === "@everyone") color = embedColor;
-			else color = user.roles?.highest.hexColor;
+			if (user.roles === undefined || user.roles.highest.name === "@everyone") color = embedColor;
+			else color = user.roles.highest.hexColor;
 
 			const embed: MessageEmbed = new MessageEmbed()
 				.setColor(color)
@@ -165,7 +165,7 @@ export default class extends Command {
 				})
 				.setDescription(description)
 				.setFooter({
-					text: await this.client.bulbutils.translate("global_executed_by", context.guild?.id, {
+					text: await this.client.bulbutils.translate("global_executed_by", context.guild.id, {
 						user: context.author,
 					}),
 					iconURL: context.author.avatarURL({ dynamic: true }) || "",

--- a/src/commands/Miscellaneous/avatar.ts
+++ b/src/commands/Miscellaneous/avatar.ts
@@ -71,7 +71,7 @@ export default class extends Command {
 					text: await this.client.bulbutils.translate("global_executed_by", context.guild?.id, {
 						user: context.author,
 					}),
-					iconURL: await this.client.bulbutils.userObject(false, context.author).avatarUrl,
+					iconURL: this.client.bulbutils.userObject(false, context.author)?.avatarUrl ?? undefined,
 				})
 				.setTimestamp();
 
@@ -91,7 +91,7 @@ export default class extends Command {
 				text: await this.client.bulbutils.translate("global_executed_by", context.guild?.id, {
 					user: context.author,
 				}),
-				iconURL: await this.client.bulbutils.userObject(false, context.author).avatarUrl,
+				iconURL: (await this.client.bulbutils.userObject(false, context.author)?.avatarUrl) ?? undefined,
 			})
 			.setTimestamp();
 

--- a/src/commands/Miscellaneous/jumbo.ts
+++ b/src/commands/Miscellaneous/jumbo.ts
@@ -124,10 +124,10 @@ export default class extends Command {
 					],
 					content: null,
 				});
-				unlinkSync(`${PATH}/final-${context.author!.id}-${context.guild!.id}.png`);
+				unlinkSync(`${PATH}/final-${context.author.id}-${context.guild?.id}.png`);
 			}
 
-			unlinkSync(`${PATH}/${context.author!.id}-${context.guild!.id}.${doesIncludeAnimatedEmoji ? "gif" : "png"}`);
+			unlinkSync(`${PATH}/${context.author.id}-${context.guild?.id}.${doesIncludeAnimatedEmoji ? "gif" : "png"}`);
 		} catch (err) {
 			this.client.log.error(`[JUMBO] ${context.author.tag} (${context.author.id}) had en error: `, err);
 			return startMessage.edit(await this.client.bulbutils.translate("jumbo_invalid", context.guild?.id, {}));

--- a/src/commands/Miscellaneous/jumbo.ts
+++ b/src/commands/Miscellaneous/jumbo.ts
@@ -37,7 +37,7 @@ export default class extends Command {
 
 		const realList: string[] = [];
 		for (let i = 0; i < args.length; i++) {
-			const customEmoji = <RegExpMatchArray>args[i].match(CustomEmote);
+			const customEmoji = args[i].match(CustomEmote);
 			if (!customEmoji) realList.push(...args[i]);
 			else {
 				realList.push(...customEmoji);
@@ -67,10 +67,10 @@ export default class extends Command {
 			jumboList.push(`${context.author.id}-${context.guild?.id}.${doesIncludeAnimatedEmoji ? "gif" : "png"}`);
 
 			for (let i = 0; i < realList.length; i++) {
-				let emote: RegExpMatchArray | string = realList[i];
+				let emote: Nullable<RegExpMatchArray | string> = realList[i];
 				let emoteName: string;
 
-				emote = <RegExpMatchArray>emote.match(CustomEmote);
+				emote = emote.match(CustomEmote);
 
 				if (emote === null) {
 					emoteName = await emojiUnicode(realList[i]).split(" ").join("-");
@@ -81,8 +81,9 @@ export default class extends Command {
 				} else {
 					const extension = emote[0].startsWith("<a:") ? "gif" : "png";
 					emote = emote[0].substring(1).slice(0, -1);
-					emote = <RegExpMatchArray>emote.match(GetEverythingAfterColon);
+					emote = emote.match(GetEverythingAfterColon) || [];
 					emoteName = emote[0];
+					if (!emoteName) continue;
 
 					if (!existsSync(join(PATH, `${emoteName}.${extension}`)))
 						await DownloadEmoji(`https://cdn.discordapp.com/emojis/${emoteName}.${extension}?v=1&quality=lossless`, extension, emote, emoteName, SIZE, PATH, TWEMOJI_VERSION);
@@ -149,7 +150,7 @@ async function DownloadEmoji(url: string, extension: string, emote: any, emoteNa
 			return sharpEmoji;
 		});
 	} catch (error) {
-		if (CustomEmote.test(<string>(<unknown>emote))) throw error;
+		if (CustomEmote.test(emote)) throw error;
 
 		url = `https://cdnjs.cloudflare.com/ajax/libs/twemoji/${twemojiVersion}/svg/${emoteName.split("-fe0f").join("")}.svg`;
 

--- a/src/commands/Miscellaneous/permissions.ts
+++ b/src/commands/Miscellaneous/permissions.ts
@@ -102,7 +102,7 @@ export default class extends Command {
 				text: await this.client.bulbutils.translate("global_executed_by", context.guild?.id, {
 					user: context.author,
 				}),
-				iconURL: <string>context.author.avatarURL({ dynamic: true }),
+				iconURL: context.author.avatarURL({ dynamic: true }) || "",
 			})
 			.setTimestamp();
 

--- a/src/commands/Miscellaneous/remind/set.ts
+++ b/src/commands/Miscellaneous/remind/set.ts
@@ -24,11 +24,11 @@ export default class extends SubCommand {
 	}
 
 	public async run(context: CommandContext, args: string[]): Promise<void | Message> {
-		let duration: number = <number>parse(args[0]);
+		let duration: number = parse(args[0]);
 		const reason: string = args.slice(1).join(" ");
 
 		if (duration <= 0) return context.channel.send(await this.client.bulbutils.translate("duration_invalid_0s", context.guild?.id, {}));
-		if (duration > <number>parse("1y")) return context.channel.send(await this.client.bulbutils.translate("duration_invalid_1y", context.guild?.id, {}));
+		if (duration > parse("1y")) return context.channel.send(await this.client.bulbutils.translate("duration_invalid_1y", context.guild?.id, {}));
 
 		const row = new MessageActionRow().addComponents([
 			new MessageButton()
@@ -111,7 +111,7 @@ export default class extends SubCommand {
 				}
 
 				await deleteReminder(reminder.id);
-			}, <number>parse(args[0]));
+			}, parse(args[0]));
 		});
 	}
 }

--- a/src/commands/Miscellaneous/snowflake.ts
+++ b/src/commands/Miscellaneous/snowflake.ts
@@ -49,7 +49,7 @@ export default class extends Command {
 				text: await this.client.bulbutils.translate("global_executed_by", context.guild?.id, {
 					user: context.author,
 				}),
-				iconURL: <string>context.author.avatarURL({ dynamic: true }),
+				iconURL: context.author.avatarURL({ dynamic: true }) || "",
 			})
 			.setTimestamp();
 

--- a/src/commands/Moderation/ban.ts
+++ b/src/commands/Moderation/ban.ts
@@ -1,6 +1,6 @@
 import Command from "../../structures/Command";
 import CommandContext from "../../structures/CommandContext";
-import { ButtonInteraction, Collection, Guild, GuildMember, Message, MessageActionRow, MessageButton, Snowflake, User } from "discord.js";
+import { ButtonInteraction, Collection, Message, MessageActionRow, MessageButton, Snowflake, User } from "discord.js";
 import { NonDigits } from "../../utils/Regex";
 import InfractionsManager from "../../utils/managers/InfractionsManager";
 import { BanType } from "../../utils/types/BanType";
@@ -84,15 +84,17 @@ export default class extends Command {
 					return interaction.reply({ content: await this.client.bulbutils.translate("global_not_invoked_by_user", context.guild?.id, {}), ephemeral: true });
 				}
 
+				if (!context.guild?.id || !context.member) return interaction.reply({ content: await this.client.bulbutils.translate("global_error.unknown", context.guild?.id, {}), ephemeral: true });
+
 				if (interaction.customId === "confirm") {
 					collector.stop("clicked");
 
 					infID = await infractionsManager.ban(
 						this.client,
-						<Guild>context.guild,
+						context.guild,
 						BanType.FORCE,
-						<User>target,
-						<GuildMember>context.member,
+						target,
+						context.member,
 						await this.client.bulbutils.translate("global_mod_action_log", context.guild?.id, {
 							action: await this.client.bulbutils.translate("mod_action_types.force_ban", context.guild?.id, {}),
 							moderator: context.author,
@@ -124,14 +126,15 @@ export default class extends Command {
 				return;
 			});
 		} else {
+			if (!context.guild?.id || !context.member) return;
 			//Else execute a normal ban
 			target = target.user;
 			infID = await infractionsManager.ban(
 				this.client,
-				<Guild>context.guild,
+				context.guild,
 				BanType.NORMAL,
 				target,
-				<GuildMember>context.member,
+				context.member,
 				await this.client.bulbutils.translate("global_mod_action_log", context.guild?.id, {
 					action: await this.client.bulbutils.translate("mod_action_types.ban", context.guild?.id, {}),
 					moderator: context.author,

--- a/src/commands/Moderation/ban.ts
+++ b/src/commands/Moderation/ban.ts
@@ -95,8 +95,8 @@ export default class extends Command {
 						BanType.FORCE,
 						target,
 						context.member,
-						await this.client.bulbutils.translate("global_mod_action_log", context.guild?.id, {
-							action: await this.client.bulbutils.translate("mod_action_types.force_ban", context.guild?.id, {}),
+						await this.client.bulbutils.translate("global_mod_action_log", context.guild.id, {
+							action: await this.client.bulbutils.translate("mod_action_types.force_ban", context.guild.id, {}),
 							moderator: context.author,
 							target,
 							reason,
@@ -105,8 +105,8 @@ export default class extends Command {
 					);
 
 					return await interaction.update({
-						content: await this.client.bulbutils.translate("action_success", context.guild?.id, {
-							action: await this.client.bulbutils.translate("mod_action_types.ban", context.guild?.id, {}),
+						content: await this.client.bulbutils.translate("action_success", context.guild.id, {
+							action: await this.client.bulbutils.translate("mod_action_types.ban", context.guild.id, {}),
 							target,
 							reason,
 							infraction_id: infID,
@@ -115,7 +115,7 @@ export default class extends Command {
 					});
 				} else {
 					collector.stop("clicked");
-					return interaction.update({ content: await this.client.bulbutils.translate("global_execution_cancel", context.guild?.id, {}), components: [] });
+					return interaction.update({ content: await this.client.bulbutils.translate("global_execution_cancel", context.guild.id, {}), components: [] });
 				}
 			});
 
@@ -135,8 +135,8 @@ export default class extends Command {
 				BanType.NORMAL,
 				target,
 				context.member,
-				await this.client.bulbutils.translate("global_mod_action_log", context.guild?.id, {
-					action: await this.client.bulbutils.translate("mod_action_types.ban", context.guild?.id, {}),
+				await this.client.bulbutils.translate("global_mod_action_log", context.guild.id, {
+					action: await this.client.bulbutils.translate("mod_action_types.ban", context.guild.id, {}),
 					moderator: context.author,
 					target,
 					reason,
@@ -145,8 +145,8 @@ export default class extends Command {
 			);
 
 			await context.channel.send(
-				await this.client.bulbutils.translate("action_success", context.guild?.id, {
-					action: await this.client.bulbutils.translate("mod_action_types.ban", context.guild?.id, {}),
+				await this.client.bulbutils.translate("action_success", context.guild.id, {
+					action: await this.client.bulbutils.translate("mod_action_types.ban", context.guild.id, {}),
 					target,
 					reason,
 					infraction_id: infID,

--- a/src/commands/Moderation/cleanban.ts
+++ b/src/commands/Moderation/cleanban.ts
@@ -1,6 +1,6 @@
 import Command from "../../structures/Command";
 import CommandContext from "../../structures/CommandContext";
-import { Guild, GuildMember, Snowflake } from "discord.js";
+import { GuildMember, Snowflake } from "discord.js";
 import { NonDigits } from "../../utils/Regex";
 import InfractionsManager from "../../utils/managers/InfractionsManager";
 import { BanType } from "../../utils/types/BanType";
@@ -58,12 +58,14 @@ export default class extends Command {
 			return;
 		}
 
+		if (!context.guild?.id || !context.member) return;
+
 		const infID = await infractionsManager.ban(
 			this.client,
-			<Guild>context.guild,
+			context.guild,
 			BanType.CLEAN,
 			target.user,
-			<GuildMember>context.member,
+			context.member,
 			await this.client.bulbutils.translate("global_mod_action_log", context.guild?.id, {
 				action: await this.client.bulbutils.translate("mod_action_types.ban", context.guild?.id, {}),
 				moderator: context.author,

--- a/src/commands/Moderation/cleanban.ts
+++ b/src/commands/Moderation/cleanban.ts
@@ -66,8 +66,8 @@ export default class extends Command {
 			BanType.CLEAN,
 			target.user,
 			context.member,
-			await this.client.bulbutils.translate("global_mod_action_log", context.guild?.id, {
-				action: await this.client.bulbutils.translate("mod_action_types.ban", context.guild?.id, {}),
+			await this.client.bulbutils.translate("global_mod_action_log", context.guild.id, {
+				action: await this.client.bulbutils.translate("mod_action_types.ban", context.guild.id, {}),
 				moderator: context.author,
 				target,
 				reason,
@@ -76,8 +76,8 @@ export default class extends Command {
 		);
 
 		await context.channel.send(
-			await this.client.bulbutils.translate("action_success", context.guild?.id, {
-				action: await this.client.bulbutils.translate("mod_action_types.ban", context.guild?.id, {}),
+			await this.client.bulbutils.translate("action_success", context.guild.id, {
+				action: await this.client.bulbutils.translate("mod_action_types.ban", context.guild.id, {}),
 				target: target.user,
 				reason,
 				infraction_id: infID,

--- a/src/commands/Moderation/crossban.ts
+++ b/src/commands/Moderation/crossban.ts
@@ -40,15 +40,15 @@ export default class extends Command {
 
 		if (!target)
 			return await context.channel.send(
-				await this.client.bulbutils.translate("global_not_found", context.guild?.id, {
-					type: await this.client.bulbutils.translate("global_not_found_types.user", context.guild?.id, {}),
+				await this.client.bulbutils.translate("global_not_found", context.guild.id, {
+					type: await this.client.bulbutils.translate("global_not_found_types.user", context.guild.id, {}),
 					arg_expected: "user:User",
 					arg_provided: args[0],
 					usage: this.usage,
 				}),
 			);
 
-		const pools: { id: number; name: string; createdAt: Date; updatedAt: Date; guildId: number }[] = await getPools(context.guild?.id);
+		const pools: { id: number; name: string; createdAt: Date; updatedAt: Date; guildId: number }[] = await getPools(context.guild.id);
 		const options: Promise<MessageSelectOptionData>[] = pools.map(async (pool) => {
 			const data = await getPoolData(pool.name);
 
@@ -66,7 +66,7 @@ export default class extends Command {
 				.addOptions(await Promise.all(options))
 				.setMinValues(1),
 		);
-		const banpoolSelect: Message = await context.channel.send({ components: [row], content: await this.client.bulbutils.translate("crossban_select_pools", context.guild?.id, {}) });
+		const banpoolSelect: Message = await context.channel.send({ components: [row], content: await this.client.bulbutils.translate("crossban_select_pools", context.guild.id, {}) });
 		const compCollector = banpoolSelect.createMessageComponentCollector({ componentType: "SELECT_MENU", time: 60_000 });
 
 		compCollector.on("collect", async (interaction: SelectMenuInteraction) => {
@@ -82,7 +82,7 @@ export default class extends Command {
 			for (let i = 0; i < poolGuilds.length; i++) {
 				const guildId = poolGuilds[i];
 				const guild: Guild = await this.client.guilds.fetch(guildId);
-				if (!reason) reason = await this.client.bulbutils.translate("global_no_reason", guild?.id, {});
+				if (!reason) reason = await this.client.bulbutils.translate("global_no_reason", guild.id, {});
 
 				if (!guild.me?.permissions.has(Permissions.FLAGS.BAN_MEMBERS)) continue;
 
@@ -129,7 +129,7 @@ async function banUser(client: BulbBotClient, target: User, moderator: User, gui
 		client,
 		guild,
 		"banpool",
-		await client.bulbutils.translate("crossban_reason", guild?.id, {
+		await client.bulbutils.translate("crossban_reason", guild.id, {
 			emoji: Emotes.actions.BAN,
 			target,
 			startedGuild,
@@ -140,7 +140,7 @@ async function banUser(client: BulbBotClient, target: User, moderator: User, gui
 	);
 
 	guild.members.ban(target, {
-		reason: await client.bulbutils.translate("crossban_reason_audit", guild?.id, {
+		reason: await client.bulbutils.translate("crossban_reason_audit", guild.id, {
 			startedGuild,
 			moderator,
 			reason,

--- a/src/commands/Moderation/crossban.ts
+++ b/src/commands/Moderation/crossban.ts
@@ -87,19 +87,20 @@ export default class extends Command {
 				if (!guild.me?.permissions.has(Permissions.FLAGS.BAN_MEMBERS)) continue;
 
 				const banList = await guild.bans.fetch();
-				const bannedUser = banList.find((ban: GuildBan) => ban.user.id === target!.id);
+				const bannedUser = banList.find((ban: GuildBan) => ban.user.id === target.id);
 
 				if (bannedUser) continue;
 				else {
-					const guildTarget: GuildMember | undefined = await tryIgnore(() => this.client.bulbfetch.getGuildMember(guild?.members, target!.id));
+					if (!context.guild) continue;
+					const guildTarget: GuildMember | undefined = await tryIgnore(() => this.client.bulbfetch.getGuildMember(guild.members, target.id));
 
 					if (!guildTarget) {
 						totalBans++;
-						banUser(this.client, target!, context.author, guild, context.guild!, reason);
+						banUser(this.client, target, context.author, guild, context.guild, reason);
 					} else {
 						if (guildTarget.bannable) {
 							totalBans++;
-							banUser(this.client, target!, context.author, guild, context.guild!, reason);
+							banUser(this.client, target, context.author, guild, context.guild, reason);
 						} else continue;
 					}
 				}

--- a/src/commands/Moderation/deafen.ts
+++ b/src/commands/Moderation/deafen.ts
@@ -49,8 +49,8 @@ export default class extends Command {
 			context.guild,
 			target,
 			context.member,
-			await this.client.bulbutils.translate("global_mod_action_log", context.guild?.id, {
-				action: await this.client.bulbutils.translate("mod_action_types.deafen", context.guild?.id, {}),
+			await this.client.bulbutils.translate("global_mod_action_log", context.guild.id, {
+				action: await this.client.bulbutils.translate("mod_action_types.deafen", context.guild.id, {}),
 				moderator: context.author,
 				target: target.user,
 				reason,
@@ -59,8 +59,8 @@ export default class extends Command {
 		);
 
 		await context.channel.send(
-			await this.client.bulbutils.translate("action_success", context.guild?.id, {
-				action: await this.client.bulbutils.translate("mod_action_types.deafen", context.guild?.id, {}),
+			await this.client.bulbutils.translate("action_success", context.guild.id, {
+				action: await this.client.bulbutils.translate("mod_action_types.deafen", context.guild.id, {}),
 				target: target.user,
 				reason,
 				infraction_id: infID,

--- a/src/commands/Moderation/deafen.ts
+++ b/src/commands/Moderation/deafen.ts
@@ -1,6 +1,6 @@
 import Command from "../../structures/Command";
 import CommandContext from "../../structures/CommandContext";
-import { Guild, GuildMember, Message, Snowflake } from "discord.js";
+import { GuildMember, Message, Snowflake } from "discord.js";
 import { NonDigits } from "../../utils/Regex";
 import InfractionsManager from "../../utils/managers/InfractionsManager";
 import BulbBotClient from "../../structures/BulbBotClient";
@@ -42,12 +42,13 @@ export default class extends Command {
 		if (await this.client.bulbutils.resolveUserHandle(context, this.client.bulbutils.checkUser(context, target), target.user)) return;
 		if (!target.voice.channel) return context.channel.send(await this.client.bulbutils.translate("global_not_in_voice", context.guild?.id, { target: target.user }));
 		if (target.voice.serverDeaf) return context.channel.send(await this.client.bulbutils.translate("deafen_already_deaf", context.guild?.id, { target: target.user }));
+		if (!context.guild?.id || !context.member) return;
 
 		const infID = await infractionsManager.deafen(
 			this.client,
-			<Guild>context.guild,
+			context.guild,
 			target,
-			<GuildMember>context.member,
+			context.member,
 			await this.client.bulbutils.translate("global_mod_action_log", context.guild?.id, {
 				action: await this.client.bulbutils.translate("mod_action_types.deafen", context.guild?.id, {}),
 				moderator: context.author,

--- a/src/commands/Moderation/infraction/claim.ts
+++ b/src/commands/Moderation/infraction/claim.ts
@@ -2,7 +2,7 @@ import BulbBotClient from "../../../structures/BulbBotClient";
 import Command from "../../../structures/Command";
 import SubCommand from "../../../structures/SubCommand";
 import CommandContext from "../../../structures/CommandContext";
-import { Message, Snowflake, User } from "discord.js";
+import { Message } from "discord.js";
 import InfractionsManager from "../../../utils/managers/InfractionsManager";
 import { NonDigits } from "../../../utils/Regex";
 
@@ -22,27 +22,28 @@ export default class extends SubCommand {
 	}
 
 	public async run(context: CommandContext, args: string[]): Promise<void | Message> {
+		if (!context.guild || !context.member) return;
 		const infID = Number(args[0].replace(NonDigits, ""));
 
 		if (!infID || infID >= 2147483647 || infID <= 0)
 			return context.channel.send(
-				await this.client.bulbutils.translate("global_cannot_convert", context.guild?.id, {
-					type: await this.client.bulbutils.translate("global_not_found_types.int", context.guild?.id, {}),
+				await this.client.bulbutils.translate("global_cannot_convert", context.guild.id, {
+					type: await this.client.bulbutils.translate("global_not_found_types.int", context.guild.id, {}),
 					arg_expected: "id:Number",
 					arg_provided: args[0],
 					usage: this.usage,
 				}),
 			);
 
-		if ((await infractionsManager.getInfraction(<Snowflake>context.guild?.id, Number(args[0].replace(NonDigits, "")))) === undefined) {
+		if ((await infractionsManager.getInfraction(context.guild.id, Number(args[0].replace(NonDigits, "")))) === undefined) {
 			return context.channel.send(
-				await this.client.bulbutils.translate("infraction_not_found", context.guild?.id, {
+				await this.client.bulbutils.translate("infraction_not_found", context.guild.id, {
 					infraction_id: args[0],
 				}),
 			);
 		}
 
-		await infractionsManager.updateModerator(<Snowflake>context.guild?.id, Number(args[0].replace(NonDigits, "")), <User>context.member?.user);
-		return await context.channel.send(await this.client.bulbutils.translate("infraction_claim_success", context.guild?.id, { infraction_id: args[0] }));
+		await infractionsManager.updateModerator(context.guild.id, Number(args[0].replace(NonDigits, "")), context.member.user);
+		return await context.channel.send(await this.client.bulbutils.translate("infraction_claim_success", context.guild.id, { infraction_id: args[0] }));
 	}
 }

--- a/src/commands/Moderation/infraction/info.ts
+++ b/src/commands/Moderation/infraction/info.ts
@@ -30,8 +30,8 @@ export default class extends SubCommand {
 
 		if (!infID || infID >= 2147483647 || infID <= 0)
 			return context.channel.send(
-				await this.client.bulbutils.translate("global_cannot_convert", context.guild?.id, {
-					type: await this.client.bulbutils.translate("global_not_found_types.int", context.guild?.id, {}),
+				await this.client.bulbutils.translate("global_cannot_convert", context.guild.id, {
+					type: await this.client.bulbutils.translate("global_not_found_types.int", context.guild.id, {}),
 					arg_expected: "id:Number",
 					arg_provided: args[0],
 					usage: this.usage,
@@ -42,7 +42,7 @@ export default class extends SubCommand {
 
 		if (!inf) {
 			return context.channel.send(
-				await this.client.bulbutils.translate("infraction_not_found", context.guild?.id, {
+				await this.client.bulbutils.translate("infraction_not_found", context.guild.id, {
 					infraction_id: args[0].replace(NonDigits, ""),
 				}),
 			);
@@ -53,24 +53,24 @@ export default class extends SubCommand {
 		const moderator: Record<string, string> = { tag: inf.moderator, id: inf.moderatorId };
 
 		let description = "";
-		description += await this.client.bulbutils.translate("infraction_info_inf_id", context.guild?.id, { infraction_id: args[0] });
-		description += await this.client.bulbutils.translate("infraction_info_target", context.guild?.id, { target });
-		description += await this.client.bulbutils.translate("infraction_info_moderator", context.guild?.id, { moderator });
-		description += await this.client.bulbutils.translate("infraction_info_created", context.guild?.id, {
+		description += await this.client.bulbutils.translate("infraction_info_inf_id", context.guild.id, { infraction_id: args[0] });
+		description += await this.client.bulbutils.translate("infraction_info_target", context.guild.id, { target });
+		description += await this.client.bulbutils.translate("infraction_info_moderator", context.guild.id, { moderator });
+		description += await this.client.bulbutils.translate("infraction_info_created", context.guild.id, {
 			created: moment(Date.parse(inf.createdAt)).format("MMM Do YYYY, h:mm:ss a"),
 		});
 
 		if (inf.active !== "false" && inf.active !== "true") {
-			description += await this.client.bulbutils.translate("infraction_info_expires", context.guild?.id, {
+			description += await this.client.bulbutils.translate("infraction_info_expires", context.guild.id, {
 				expires: `${Emotes.status.ONLINE} ${moment(parseInt(inf.active)).format("MMM Do YYYY, h:mm:ss a")}`,
 			});
 		} else {
-			description += await this.client.bulbutils.translate("infraction_info_active", context.guild?.id, {
+			description += await this.client.bulbutils.translate("infraction_info_active", context.guild.id, {
 				active: this.client.bulbutils.prettify(inf.active),
 			});
 		}
 
-		description += await this.client.bulbutils.translate("infraction_info_reason", context.guild?.id, { reason: inf.reason });
+		description += await this.client.bulbutils.translate("infraction_info_reason", context.guild.id, { reason: inf.reason });
 
 		const image = inf.reason.match(ReasonImage);
 
@@ -82,7 +82,7 @@ export default class extends SubCommand {
 			.setImage(image ? image[0] : "")
 			.setThumbnail(user?.avatarURL({ dynamic: true }) || "")
 			.setFooter({
-				text: await this.client.bulbutils.translate("global_executed_by", context.guild?.id, { user: context.author }),
+				text: await this.client.bulbutils.translate("global_executed_by", context.guild.id, { user: context.author }),
 				iconURL: context.author.avatarURL() || "",
 			})
 			.setTimestamp();

--- a/src/commands/Moderation/infraction/modsearch.ts
+++ b/src/commands/Moderation/infraction/modsearch.ts
@@ -44,14 +44,14 @@ export default class extends SubCommand {
 		const options: any[] = [];
 		const infs: Infraction[] = (await infractionsManager.getModeratorInfractions(context.guild.id, user.id)) || [];
 
-		if (!infs.length) return await context.channel.send(await this.client.bulbutils.translate("infraction_search_not_found", context.guild?.id, { target: user }));
+		if (!infs.length) return await context.channel.send(await this.client.bulbutils.translate("infraction_search_not_found", context.guild.id, { target: user }));
 
 		for (let i = 0; i < 25; i++) {
 			if (infs[i] === undefined) continue;
 
 			options.push({
 				label: `${infs[i].action} (#${infs[i].id})`,
-				description: await this.client.bulbutils.translate("infraction_interaction_description", context.guild?.id, {}),
+				description: await this.client.bulbutils.translate("infraction_interaction_description", context.guild.id, {}),
 				value: `inf_${infs[i].id}`,
 				emoji: this.client.bulbutils.formatAction(infs[i].action),
 			});
@@ -59,13 +59,13 @@ export default class extends SubCommand {
 
 		const row = new MessageActionRow().addComponents(
 			new MessageSelectMenu()
-				.setPlaceholder(await this.client.bulbutils.translate("infraction_interaction_placeholder", context.guild?.id, {}))
+				.setPlaceholder(await this.client.bulbutils.translate("infraction_interaction_placeholder", context.guild.id, {}))
 				.setCustomId("infraction")
 				.addOptions(options),
 		);
 
 		return await context.channel.send({
-			content: await this.client.bulbutils.translate("infraction_interaction_reply", context.guild?.id, {
+			content: await this.client.bulbutils.translate("infraction_interaction_reply", context.guild.id, {
 				target: user,
 			}),
 			components: [row],

--- a/src/commands/Moderation/infraction/modsearch.ts
+++ b/src/commands/Moderation/infraction/modsearch.ts
@@ -24,13 +24,17 @@ export default class extends SubCommand {
 	}
 
 	public async run(context: CommandContext, args: string[]): Promise<void | Message> {
+		// TODO: All these returns where it shouldn't really be possible and we are just trying to narrow the type,
+		//       we should probably have a special error message & error log for, so that we notice them
+		if (!context.guild) return;
+
 		const targetID: Snowflake = args[0].replace(NonDigits, "");
 		const user: User | undefined = await this.client.bulbfetch.getUser(targetID);
 
 		if (!user)
 			return context.channel.send(
-				await this.client.bulbutils.translate("global_not_found", context.guild?.id, {
-					type: await this.client.bulbutils.translate("global_not_found_types.user", context.guild?.id, {}),
+				await this.client.bulbutils.translate("global_not_found", context.guild.id, {
+					type: await this.client.bulbutils.translate("global_not_found_types.user", context.guild.id, {}),
 					arg_expected: "user:User",
 					arg_provided: args[0],
 					usage: this.usage,
@@ -38,7 +42,7 @@ export default class extends SubCommand {
 			);
 
 		const options: any[] = [];
-		const infs: Infraction[] = <Infraction[]>await infractionsManager.getModeratorInfractions(<Snowflake>context.guild?.id, user.id);
+		const infs: Infraction[] = (await infractionsManager.getModeratorInfractions(context.guild.id, user.id)) || [];
 
 		if (!infs.length) return await context.channel.send(await this.client.bulbutils.translate("infraction_search_not_found", context.guild?.id, { target: user }));
 

--- a/src/commands/Moderation/infraction/offendersearch.ts
+++ b/src/commands/Moderation/infraction/offendersearch.ts
@@ -42,14 +42,14 @@ export default class extends SubCommand {
 		const options: any[] = [];
 		const infs: Infraction[] = (await infractionsManager.getOffenderInfractions(context.guild.id, user.id)) || [];
 
-		if (!infs.length) return await context.channel.send(await this.client.bulbutils.translate("infraction_search_not_found", context.guild?.id, { target: user }));
+		if (!infs.length) return await context.channel.send(await this.client.bulbutils.translate("infraction_search_not_found", context.guild.id, { target: user }));
 
 		for (let i = 0; i < 25; i++) {
 			if (infs[i] === undefined) continue;
 
 			options.push({
 				label: `${infs[i].action} (#${infs[i].id})`,
-				description: await this.client.bulbutils.translate("infraction_interaction_description", context.guild?.id, {}),
+				description: await this.client.bulbutils.translate("infraction_interaction_description", context.guild.id, {}),
 				value: `inf_${infs[i].id}`,
 				emoji: this.client.bulbutils.formatAction(infs[i].action),
 			});
@@ -57,13 +57,13 @@ export default class extends SubCommand {
 
 		const row = new MessageActionRow().addComponents(
 			new MessageSelectMenu()
-				.setPlaceholder(await this.client.bulbutils.translate("infraction_interaction_placeholder", context.guild?.id, {}))
+				.setPlaceholder(await this.client.bulbutils.translate("infraction_interaction_placeholder", context.guild.id, {}))
 				.setCustomId("infraction")
 				.addOptions(options),
 		);
 
 		return await context.channel.send({
-			content: await this.client.bulbutils.translate("infraction_interaction_reply", context.guild?.id, {
+			content: await this.client.bulbutils.translate("infraction_interaction_reply", context.guild.id, {
 				target: user,
 			}),
 			components: [row],

--- a/src/commands/Moderation/infraction/offendersearch.ts
+++ b/src/commands/Moderation/infraction/offendersearch.ts
@@ -24,13 +24,15 @@ export default class extends SubCommand {
 	}
 
 	public async run(context: CommandContext, args: string[]): Promise<void | Message> {
+		if (!context.guild) return;
+
 		const targetID: Snowflake = args[0].replace(NonDigits, "");
 		const user: User | undefined = await this.client.bulbfetch.getUser(targetID);
 
 		if (!user)
 			return context.channel.send(
-				await this.client.bulbutils.translate("global_not_found", context.guild?.id, {
-					type: await this.client.bulbutils.translate("global_not_found_types.user", context.guild?.id, {}),
+				await this.client.bulbutils.translate("global_not_found", context.guild.id, {
+					type: await this.client.bulbutils.translate("global_not_found_types.user", context.guild.id, {}),
 					arg_provided: args[0],
 					arg_expected: "user:User",
 					usage: this.usage,
@@ -38,7 +40,7 @@ export default class extends SubCommand {
 			);
 
 		const options: any[] = [];
-		const infs: Infraction[] = <Infraction[]>await infractionsManager.getOffenderInfractions(<Snowflake>context.guild?.id, user.id);
+		const infs: Infraction[] = (await infractionsManager.getOffenderInfractions(context.guild.id, user.id)) || [];
 
 		if (!infs.length) return await context.channel.send(await this.client.bulbutils.translate("infraction_search_not_found", context.guild?.id, { target: user }));
 

--- a/src/commands/Moderation/infraction/remove.ts
+++ b/src/commands/Moderation/infraction/remove.ts
@@ -1,11 +1,10 @@
 import Command from "../../../structures/Command";
 import SubCommand from "../../../structures/SubCommand";
 import CommandContext from "../../../structures/CommandContext";
-import { ButtonInteraction, Message, MessageActionRow, MessageButton, Snowflake } from "discord.js";
+import { ButtonInteraction, Message, MessageActionRow, MessageButton } from "discord.js";
 import InfractionsManager from "../../../utils/managers/InfractionsManager";
 import BulbBotClient from "../../../structures/BulbBotClient";
 import { NonDigits } from "../../../utils/Regex";
-import { Infraction } from "../../../utils/types/DatabaseStructures";
 
 const infractionsManager: InfractionsManager = new InfractionsManager();
 
@@ -24,27 +23,30 @@ export default class extends SubCommand {
 	}
 
 	public async run(context: CommandContext, args: string[]): Promise<void | Message> {
+		if (!context.guild) return;
 		const infID = Number(args[0].replace(NonDigits, ""));
 
 		if (!infID || infID >= 2147483647 || infID <= 0)
 			return context.channel.send(
-				await this.client.bulbutils.translate("global_cannot_convert", context.guild?.id, {
-					type: await this.client.bulbutils.translate("global_not_found_types.int", context.guild?.id, {}),
+				await this.client.bulbutils.translate("global_cannot_convert", context.guild.id, {
+					type: await this.client.bulbutils.translate("global_not_found_types.int", context.guild.id, {}),
 					arg_expected: "id:Number",
 					arg_provided: args[0],
 					usage: this.usage,
 				}),
 			);
 
-		if (isNaN(infID) || (await infractionsManager.getInfraction(<Snowflake>context.guild?.id, infID)) === undefined) {
+		if (isNaN(infID) || (await infractionsManager.getInfraction(context.guild.id, infID)) === undefined) {
 			return context.channel.send(
-				await this.client.bulbutils.translate("infraction_not_found", context.guild?.id, {
+				await this.client.bulbutils.translate("infraction_not_found", context.guild.id, {
 					infraction_id: args[0],
 				}),
 			);
 		}
 
-		const inf: Infraction = <Infraction>await infractionsManager.getInfraction(<Snowflake>context.guild?.id, infID);
+		const inf = await infractionsManager.getInfraction(context.guild.id, infID);
+		// TODO: send a not_found message
+		if (!inf) return;
 		const target: Record<string, string> = { tag: inf.target, id: inf.targetId };
 		const moderator: Record<string, string> = { tag: inf.moderator, id: inf.moderatorId };
 
@@ -54,7 +56,7 @@ export default class extends SubCommand {
 		]);
 
 		const confirmMsg = await context.channel.send({
-			content: await this.client.bulbutils.translate("infraction_delete_confirm", context.guild?.id, {
+			content: await this.client.bulbutils.translate("infraction_delete_confirm", context.guild.id, {
 				infraction_id: inf.id,
 				moderator,
 				target,
@@ -69,26 +71,27 @@ export default class extends SubCommand {
 			if (interaction.user.id !== context.author.id) {
 				return interaction.reply({ content: await this.client.bulbutils.translate("global_not_invoked_by_user", context.guild?.id, {}), ephemeral: true });
 			}
-
+			if (!context.guild) return interaction.reply({ content: await this.client.bulbutils.translate("global_error.unknown", undefined, {}), ephemeral: true });
 			if (interaction.customId === "confirm") {
 				await interaction.update({
-					content: await this.client.bulbutils.translate("infraction_delete_success", context.guild?.id, {
+					content: await this.client.bulbutils.translate("infraction_delete_success", context.guild.id, {
 						infraction_id: infID,
 					}),
 					components: [],
 				});
 				collector.stop("clicked");
-				return await infractionsManager.deleteInfraction(<Snowflake>context.guild?.id, infID);
+				return await infractionsManager.deleteInfraction(context.guild.id, infID);
 			} else {
 				collector.stop("clicked");
-				return interaction.update({ content: await this.client.bulbutils.translate("global_execution_cancel", context.guild?.id, {}), components: [] });
+				return interaction.update({ content: await this.client.bulbutils.translate("global_execution_cancel", context.guild.id, {}), components: [] });
 			}
 		});
 
 		collector.on("end", async (_: ButtonInteraction, reason: string) => {
 			if (reason !== "time") return;
+			if (!context.guild) return void (await confirmMsg.edit({ content: await this.client.bulbutils.translate("global_error.unknown", undefined, {}) }));
 
-			await confirmMsg.edit({ content: await this.client.bulbutils.translate("global_execution_cancel", context.guild?.id, {}), components: [] });
+			await confirmMsg.edit({ content: await this.client.bulbutils.translate("global_execution_cancel", context.guild.id, {}), components: [] });
 			return;
 		});
 	}

--- a/src/commands/Moderation/infraction/search.ts
+++ b/src/commands/Moderation/infraction/search.ts
@@ -43,14 +43,14 @@ export default class extends SubCommand {
 		const options: any[] = [];
 		const infs: Infraction[] = (await infractionManager.getAllUserInfractions(context.guild.id, user.id, page)) || [];
 
-		if (!infs.length) return await context.channel.send(await this.client.bulbutils.translate("infraction_search_not_found", context.guild?.id, { target: user }));
+		if (!infs.length) return await context.channel.send(await this.client.bulbutils.translate("infraction_search_not_found", context.guild.id, { target: user }));
 
 		for (let i = 0; i < 25; i++) {
-			if (infs?.[i] === undefined) continue;
+			if (infs[i] === undefined) continue;
 
 			options.push({
 				label: `${infs[i].action} (#${infs[i].id})`,
-				description: await this.client.bulbutils.translate("infraction_interaction_description", context.guild?.id, {}),
+				description: await this.client.bulbutils.translate("infraction_interaction_description", context.guild.id, {}),
 				value: `inf_${infs[i].id}`,
 				emoji: this.client.bulbutils.formatAction(infs[i].action),
 			});
@@ -58,13 +58,13 @@ export default class extends SubCommand {
 
 		const row = new MessageActionRow().addComponents(
 			new MessageSelectMenu()
-				.setPlaceholder(await this.client.bulbutils.translate("infraction_interaction_placeholder", context.guild?.id, {}))
+				.setPlaceholder(await this.client.bulbutils.translate("infraction_interaction_placeholder", context.guild.id, {}))
 				.setCustomId("infraction")
 				.addOptions(options),
 		);
 
 		return await context.channel.send({
-			content: await this.client.bulbutils.translate("infraction_interaction_reply", context.guild?.id, {
+			content: await this.client.bulbutils.translate("infraction_interaction_reply", context.guild.id, {
 				target: user,
 			}),
 			components: [row],

--- a/src/commands/Moderation/infraction/search.ts
+++ b/src/commands/Moderation/infraction/search.ts
@@ -23,6 +23,8 @@ export default class extends SubCommand {
 	}
 
 	public async run(context: CommandContext, args: string[]): Promise<void | Message> {
+		if (!context.guild) return;
+
 		const targetID: Snowflake = args[0].replace(NonDigits, "");
 		const user: User | undefined = await this.client.bulbfetch.getUser(targetID);
 		let page = Number(args[1]);
@@ -30,8 +32,8 @@ export default class extends SubCommand {
 
 		if (!user)
 			return context.channel.send(
-				await this.client.bulbutils.translate("global_not_found", context.guild?.id, {
-					type: await this.client.bulbutils.translate("global_not_found_types.user", context.guild?.id, {}),
+				await this.client.bulbutils.translate("global_not_found", context.guild.id, {
+					type: await this.client.bulbutils.translate("global_not_found_types.user", context.guild.id, {}),
 					arg_provided: args[0],
 					arg_expected: "user:User",
 					usage: this.usage,
@@ -39,7 +41,7 @@ export default class extends SubCommand {
 			);
 
 		const options: any[] = [];
-		const infs: Infraction[] = <Infraction[]>await infractionManager.getAllUserInfractions(<string>context.guild?.id, user.id, page);
+		const infs: Infraction[] = (await infractionManager.getAllUserInfractions(context.guild.id, user.id, page)) || [];
 
 		if (!infs.length) return await context.channel.send(await this.client.bulbutils.translate("infraction_search_not_found", context.guild?.id, { target: user }));
 

--- a/src/commands/Moderation/infraction/update.ts
+++ b/src/commands/Moderation/infraction/update.ts
@@ -28,8 +28,8 @@ export default class extends SubCommand {
 
 		if (!infID || infID >= 2147483647 || infID <= 0)
 			return context.channel.send(
-				await this.client.bulbutils.translate("global_cannot_convert", context.guild?.id, {
-					type: await this.client.bulbutils.translate("global_not_found_types.int", context.guild?.id, {}),
+				await this.client.bulbutils.translate("global_cannot_convert", context.guild.id, {
+					type: await this.client.bulbutils.translate("global_not_found_types.int", context.guild.id, {}),
 					arg_expected: "id:Number",
 					arg_provided: args[0],
 					usage: this.usage,
@@ -38,7 +38,7 @@ export default class extends SubCommand {
 
 		if (!(await infractionsManager.getInfraction(context.guild.id, Number(args[0].replace(NonDigits, ""))))) {
 			return context.channel.send(
-				await this.client.bulbutils.translate("infraction_not_found", context.guild?.id, {
+				await this.client.bulbutils.translate("infraction_not_found", context.guild.id, {
 					infraction_id: args[0],
 				}),
 			);
@@ -46,6 +46,6 @@ export default class extends SubCommand {
 
 		const reason = args.slice(1).join(" ");
 		await infractionsManager.updateReason(context.guild.id, Number(args[0]), reason);
-		return context.channel.send(await this.client.bulbutils.translate("infraction_update_success", context.guild?.id, { infraction_id: args[0] }));
+		return context.channel.send(await this.client.bulbutils.translate("infraction_update_success", context.guild.id, { infraction_id: args[0] }));
 	}
 }

--- a/src/commands/Moderation/infraction/update.ts
+++ b/src/commands/Moderation/infraction/update.ts
@@ -1,7 +1,7 @@
 import Command from "../../../structures/Command";
 import SubCommand from "../../../structures/SubCommand";
 import CommandContext from "../../../structures/CommandContext";
-import { Message, Snowflake } from "discord.js";
+import { Message } from "discord.js";
 import InfractionsManager from "../../../utils/managers/InfractionsManager";
 import { NonDigits } from "../../../utils/Regex";
 import BulbBotClient from "../../../structures/BulbBotClient";
@@ -22,6 +22,8 @@ export default class extends SubCommand {
 	}
 
 	public async run(context: CommandContext, args: string[]): Promise<void | Message> {
+		if (!context.guild) return;
+
 		const infID = Number(args[0].replace(NonDigits, ""));
 
 		if (!infID || infID >= 2147483647 || infID <= 0)
@@ -34,7 +36,7 @@ export default class extends SubCommand {
 				}),
 			);
 
-		if (!(await infractionsManager.getInfraction(<Snowflake>context.guild?.id, Number(args[0].replace(NonDigits, ""))))) {
+		if (!(await infractionsManager.getInfraction(context.guild.id, Number(args[0].replace(NonDigits, ""))))) {
 			return context.channel.send(
 				await this.client.bulbutils.translate("infraction_not_found", context.guild?.id, {
 					infraction_id: args[0],
@@ -43,7 +45,7 @@ export default class extends SubCommand {
 		}
 
 		const reason = args.slice(1).join(" ");
-		await infractionsManager.updateReason(<Snowflake>context.guild?.id, Number(args[0]), reason);
+		await infractionsManager.updateReason(context.guild.id, Number(args[0]), reason);
 		return context.channel.send(await this.client.bulbutils.translate("infraction_update_success", context.guild?.id, { infraction_id: args[0] }));
 	}
 }

--- a/src/commands/Moderation/kick.ts
+++ b/src/commands/Moderation/kick.ts
@@ -49,11 +49,11 @@ export default class extends Command {
 		//Executes the action
 		const infID = await infractionsManager.kick(
 			this.client,
-			context.guild?.id,
+			context.guild.id,
 			target,
 			context.member,
-			await this.client.bulbutils.translate("global_mod_action_log", context.guild?.id, {
-				action: await this.client.bulbutils.translate("mod_action_types.kick", context.guild?.id, {}),
+			await this.client.bulbutils.translate("global_mod_action_log", context.guild.id, {
+				action: await this.client.bulbutils.translate("mod_action_types.kick", context.guild.id, {}),
 				moderator: context.author,
 				target: target.user,
 				reason,
@@ -65,8 +65,8 @@ export default class extends Command {
 
 		//Sends the respond context
 		await context.channel.send(
-			await this.client.bulbutils.translate("action_success", context.guild?.id, {
-				action: await this.client.bulbutils.translate("mod_action_types.kick", context.guild?.id, {}),
+			await this.client.bulbutils.translate("action_success", context.guild.id, {
+				action: await this.client.bulbutils.translate("mod_action_types.kick", context.guild.id, {}),
 				target: target.user,
 				reason,
 				infraction_id: infID,

--- a/src/commands/Moderation/kick.ts
+++ b/src/commands/Moderation/kick.ts
@@ -44,13 +44,14 @@ export default class extends Command {
 			return;
 		}
 		if (await this.client.bulbutils.resolveUserHandle(context, this.client.bulbutils.checkUser(context, target), target.user)) return;
+		if (!context.guild?.id || !context.member) return;
 
 		//Executes the action
 		const infID = await infractionsManager.kick(
 			this.client,
-			<string>context.guild?.id,
+			context.guild?.id,
 			target,
-			<GuildMember>context.member,
+			context.member,
 			await this.client.bulbutils.translate("global_mod_action_log", context.guild?.id, {
 				action: await this.client.bulbutils.translate("mod_action_types.kick", context.guild?.id, {}),
 				moderator: context.author,

--- a/src/commands/Moderation/lockdown.ts
+++ b/src/commands/Moderation/lockdown.ts
@@ -48,9 +48,9 @@ export default class extends Command {
 
 		if (args[1] === "true") {
 			await context.channel.send(await this.client.bulbutils.translate("lockdown_locked", context.guild.id, { channel }));
-			return channel?.permissionOverwrites.edit(context.guild.roles.everyone, { SEND_MESSAGES: false });
+			return channel.permissionOverwrites.edit(context.guild.roles.everyone, { SEND_MESSAGES: false });
 		} else {
-			await channel?.permissionOverwrites.edit(context.guild.roles.everyone, { SEND_MESSAGES: null });
+			await channel.permissionOverwrites.edit(context.guild.roles.everyone, { SEND_MESSAGES: null });
 			return await context.channel.send(await this.client.bulbutils.translate("lockdown_unlocked", context.guild.id, { channel }));
 		}
 	}

--- a/src/commands/Moderation/lockdown.ts
+++ b/src/commands/Moderation/lockdown.ts
@@ -1,6 +1,6 @@
 import Command from "../../structures/Command";
 import CommandContext from "../../structures/CommandContext";
-import { Channel, GuildChannel, Message, Role, ThreadChannel } from "discord.js";
+import { Channel, GuildChannel, Message, ThreadChannel } from "discord.js";
 import { NonDigits } from "../../utils/Regex";
 import BulbBotClient from "../../structures/BulbBotClient";
 
@@ -44,12 +44,14 @@ export default class extends Command {
 			);
 		}
 
+		if (!context.guild) return;
+
 		if (args[1] === "true") {
-			await context.channel.send(await this.client.bulbutils.translate("lockdown_locked", context.guild?.id, { channel }));
-			return channel?.permissionOverwrites.edit(<Role>context.guild?.roles.everyone, { SEND_MESSAGES: false });
+			await context.channel.send(await this.client.bulbutils.translate("lockdown_locked", context.guild.id, { channel }));
+			return channel?.permissionOverwrites.edit(context.guild.roles.everyone, { SEND_MESSAGES: false });
 		} else {
-			await channel?.permissionOverwrites.edit(<Role>context.guild?.roles.everyone, { SEND_MESSAGES: null });
-			return await context.channel.send(await this.client.bulbutils.translate("lockdown_unlocked", context.guild?.id, { channel }));
+			await channel?.permissionOverwrites.edit(context.guild.roles.everyone, { SEND_MESSAGES: null });
+			return await context.channel.send(await this.client.bulbutils.translate("lockdown_unlocked", context.guild.id, { channel }));
 		}
 	}
 }

--- a/src/commands/Moderation/multiban.ts
+++ b/src/commands/Moderation/multiban.ts
@@ -28,7 +28,7 @@ export default class extends Command {
 	}
 
 	public async run(context: CommandContext, args: string[]): Promise<void | Message> {
-		let targets: RegExpMatchArray = <RegExpMatchArray>args.slice(0).join(" ").match(UserMentionAndID);
+		let targets: RegExpMatchArray = args.slice(0).join(" ").match(UserMentionAndID) || [];
 		targets = [...new Set(targets.map((target) => target.replace(NonDigits, "")))];
 
 		if (!targets.length)
@@ -49,7 +49,7 @@ export default class extends Command {
 					action: await this.client.bulbutils.translate("action_multi_types.ban", context.guild?.id, {}),
 				}),
 			);
-			return await this.client.commands.get("ban")!.run(context, args);
+			return await this.client.commands.get("ban")?.run(context, args);
 		}
 
 		context.channel.send(await this.client.bulbutils.translate("global_loading", context.guild?.id, {})).then((msg) => {

--- a/src/commands/Moderation/multiban.ts
+++ b/src/commands/Moderation/multiban.ts
@@ -1,6 +1,6 @@
 import Command from "../../structures/Command";
 import CommandContext from "../../structures/CommandContext";
-import { Guild, GuildMember, Message, Snowflake } from "discord.js";
+import { Message, Snowflake } from "discord.js";
 import { NonDigits, UserMentionAndID } from "../../utils/Regex";
 import { massCommandSleep } from "../../Config";
 import InfractionsManager from "../../utils/managers/InfractionsManager";
@@ -56,6 +56,8 @@ export default class extends Command {
 			setTimeout(() => msg.delete(), (args.length - 0.5) * massCommandSleep);
 		});
 
+		if (!context.guild?.id || !context.member) return;
+
 		for (let i = 0; i < targets.length; i++) {
 			if (targets[i] === undefined) continue;
 			await this.client.bulbutils.sleep(massCommandSleep);
@@ -85,10 +87,10 @@ export default class extends Command {
 
 				infID = await infractionsManager.ban(
 					this.client,
-					<Guild>context.guild,
+					context.guild,
 					BanType.FORCE,
 					target,
-					<GuildMember>context.member,
+					context.member,
 					await this.client.bulbutils.translate("global_mod_action_log", context.guild?.id, {
 						action: await this.client.bulbutils.translate("mod_action_types.force_ban", context.guild?.id, {}),
 						moderator: context.author,
@@ -101,10 +103,10 @@ export default class extends Command {
 				target = target.user;
 				infID = await infractionsManager.ban(
 					this.client,
-					<Guild>context.guild,
+					context.guild,
 					BanType.NORMAL,
 					target,
-					<GuildMember>context.member,
+					context.member,
 					await this.client.bulbutils.translate("global_mod_action_log", context.guild?.id, {
 						action: await this.client.bulbutils.translate("mod_action_types.ban", context.guild?.id, {}),
 						moderator: context.author,

--- a/src/commands/Moderation/multiban.ts
+++ b/src/commands/Moderation/multiban.ts
@@ -64,7 +64,7 @@ export default class extends Command {
 
 			const t: Snowflake = targets[i].replace(NonDigits, "");
 			let infID: number;
-			let target: any = await this.client.bulbfetch.getGuildMember(context.guild?.members, t);
+			let target: any = await this.client.bulbfetch.getGuildMember(context.guild.members, t);
 			const notInGuild = !target;
 
 			if (!notInGuild) {
@@ -75,8 +75,8 @@ export default class extends Command {
 				target = await this.client.bulbfetch.getUser(t);
 				if (!target) {
 					await context.channel.send(
-						await this.client.bulbutils.translate("global_not_found", context.guild?.id, {
-							type: await this.client.bulbutils.translate("global_not_found_types.user", context.guild?.id, {}),
+						await this.client.bulbutils.translate("global_not_found", context.guild.id, {
+							type: await this.client.bulbutils.translate("global_not_found_types.user", context.guild.id, {}),
 							arg_expected: "user:User",
 							arg_provided: t,
 							usage: this.usage,
@@ -91,8 +91,8 @@ export default class extends Command {
 					BanType.FORCE,
 					target,
 					context.member,
-					await this.client.bulbutils.translate("global_mod_action_log", context.guild?.id, {
-						action: await this.client.bulbutils.translate("mod_action_types.force_ban", context.guild?.id, {}),
+					await this.client.bulbutils.translate("global_mod_action_log", context.guild.id, {
+						action: await this.client.bulbutils.translate("mod_action_types.force_ban", context.guild.id, {}),
 						moderator: context.author,
 						target,
 						reason,
@@ -107,8 +107,8 @@ export default class extends Command {
 					BanType.NORMAL,
 					target,
 					context.member,
-					await this.client.bulbutils.translate("global_mod_action_log", context.guild?.id, {
-						action: await this.client.bulbutils.translate("mod_action_types.ban", context.guild?.id, {}),
+					await this.client.bulbutils.translate("global_mod_action_log", context.guild.id, {
+						action: await this.client.bulbutils.translate("mod_action_types.ban", context.guild.id, {}),
 						moderator: context.author,
 						target,
 						reason,
@@ -123,8 +123,8 @@ export default class extends Command {
 		if (!fullList.length) return;
 
 		return context.channel.send(
-			await this.client.bulbutils.translate("action_success_multi", context.guild?.id, {
-				action: await this.client.bulbutils.translate("mod_action_types.ban", context.guild?.id, {}),
+			await this.client.bulbutils.translate("action_success_multi", context.guild.id, {
+				action: await this.client.bulbutils.translate("mod_action_types.ban", context.guild.id, {}),
 				full_list: fullList.join(", "),
 				reason,
 			}),

--- a/src/commands/Moderation/multikick.ts
+++ b/src/commands/Moderation/multikick.ts
@@ -27,7 +27,7 @@ export default class extends Command {
 	}
 
 	public async run(context: CommandContext, args: string[]): Promise<void | Message> {
-		let targets: RegExpMatchArray = <RegExpMatchArray>args.slice(0).join(" ").match(UserMentionAndID);
+		let targets: RegExpMatchArray = args.slice(0).join(" ").match(UserMentionAndID) || [];
 		targets = [...new Set(targets.map((target) => target.replace(NonDigits, "")))];
 
 		if (!targets.length)
@@ -42,13 +42,13 @@ export default class extends Command {
 		if (reason === "") reason = await this.client.bulbutils.translate("global_no_reason", context.guild?.id, {});
 		const fullList: string[] = [];
 
-		if (targets!.length <= 1) {
+		if (targets.length <= 1) {
 			await context.channel.send(
 				await this.client.bulbutils.translate("action_multi_less_than_2", context.guild?.id, {
 					action: await this.client.bulbutils.translate("action_multi_types.kick", context.guild?.id, {}),
 				}),
 			);
-			return await this.client.commands.get("kick")!.run(context, args);
+			return await this.client.commands.get("kick")?.run(context, args);
 		}
 
 		context.channel.send(await this.client.bulbutils.translate("global_loading", context.guild?.id, {})).then((msg) => {

--- a/src/commands/Moderation/multikick.ts
+++ b/src/commands/Moderation/multikick.ts
@@ -1,6 +1,6 @@
 import Command from "../../structures/Command";
 import CommandContext from "../../structures/CommandContext";
-import { GuildMember, Message, Snowflake } from "discord.js";
+import { GuildMember, Message } from "discord.js";
 import { NonDigits, UserMentionAndID } from "../../utils/Regex";
 import { massCommandSleep } from "../../Config";
 import InfractionsManager from "../../utils/managers/InfractionsManager";
@@ -55,6 +55,8 @@ export default class extends Command {
 			setTimeout(() => msg.delete(), (args.length - 0.5) * massCommandSleep);
 		});
 
+		if (!context.guild?.id || !context.member) return;
+
 		for (let i = 0; i < targets.length; i++) {
 			if (targets[i] === undefined) continue;
 			await this.client.bulbutils.sleep(massCommandSleep);
@@ -77,9 +79,9 @@ export default class extends Command {
 
 			const infID = await infractionsManager.kick(
 				this.client,
-				<Snowflake>context.guild?.id,
+				context.guild?.id,
 				target,
-				<GuildMember>context.member,
+				context.member,
 				await this.client.bulbutils.translate("global_mod_action_log", context.guild?.id, {
 					action: await this.client.bulbutils.translate("mod_action_types.kick", context.guild?.id, {}),
 					moderator: context.author,

--- a/src/commands/Moderation/multikick.ts
+++ b/src/commands/Moderation/multikick.ts
@@ -62,12 +62,12 @@ export default class extends Command {
 			await this.client.bulbutils.sleep(massCommandSleep);
 
 			const t: string = targets[i].replace(NonDigits, "");
-			const target: GuildMember | undefined = await this.client.bulbfetch.getGuildMember(context.guild?.members, t);
+			const target: GuildMember | undefined = await this.client.bulbfetch.getGuildMember(context.guild.members, t);
 
 			if (!target) {
 				await context.channel.send(
-					await this.client.bulbutils.translate("global_not_found", context.guild?.id, {
-						type: await this.client.bulbutils.translate("global_not_found_types.member", context.guild?.id, {}),
+					await this.client.bulbutils.translate("global_not_found", context.guild.id, {
+						type: await this.client.bulbutils.translate("global_not_found_types.member", context.guild.id, {}),
 						arg_provided: t,
 						arg_expected: "member:Member",
 						usage: this.usage,
@@ -79,11 +79,11 @@ export default class extends Command {
 
 			const infID = await infractionsManager.kick(
 				this.client,
-				context.guild?.id,
+				context.guild.id,
 				target,
 				context.member,
-				await this.client.bulbutils.translate("global_mod_action_log", context.guild?.id, {
-					action: await this.client.bulbutils.translate("mod_action_types.kick", context.guild?.id, {}),
+				await this.client.bulbutils.translate("global_mod_action_log", context.guild.id, {
+					action: await this.client.bulbutils.translate("mod_action_types.kick", context.guild.id, {}),
 					moderator: context.author,
 					target: target.user,
 					reason,
@@ -98,8 +98,8 @@ export default class extends Command {
 		if (!fullList.length) return;
 
 		return context.channel.send(
-			await this.client.bulbutils.translate("action_success_multi", context.guild?.id, {
-				action: await this.client.bulbutils.translate("mod_action_types.kick", context.guild?.id, {}),
+			await this.client.bulbutils.translate("action_success_multi", context.guild.id, {
+				action: await this.client.bulbutils.translate("mod_action_types.kick", context.guild.id, {}),
 				full_list: fullList.join(", "),
 				reason,
 			}),

--- a/src/commands/Moderation/multiunban.ts
+++ b/src/commands/Moderation/multiunban.ts
@@ -28,7 +28,7 @@ export default class extends Command {
 	}
 
 	public async run(context: CommandContext, args: string[]): Promise<void | Message> {
-		let targets: RegExpMatchArray = <RegExpMatchArray>args.slice(0).join(" ").match(UserMentionAndID);
+		let targets: RegExpMatchArray = args.slice(0).join(" ").match(UserMentionAndID) || [];
 		targets = [...new Set(targets.map((target) => target.replace(NonDigits, "")))];
 
 		if (!targets.length)
@@ -43,13 +43,13 @@ export default class extends Command {
 		if (reason === "") reason = await this.client.bulbutils.translate("global_no_reason", context.guild?.id, {});
 		const fullList: string[] = [];
 
-		if (targets!.length <= 1) {
+		if (targets.length <= 1) {
 			await context.channel.send(
 				await this.client.bulbutils.translate("action_multi_less_than_2", context.guild?.id, {
 					action: await this.client.bulbutils.translate("action_multi_types.unban", context.guild?.id, {}),
 				}),
 			);
-			return await this.client.commands.get("unban")!.run(context, args);
+			return await this.client.commands.get("unban")?.run(context, args);
 		}
 
 		context.channel.send(await this.client.bulbutils.translate("global_loading", context.guild?.id, {})).then((msg) => {

--- a/src/commands/Moderation/multiunban.ts
+++ b/src/commands/Moderation/multiunban.ts
@@ -1,6 +1,6 @@
 import Command from "../../structures/Command";
 import CommandContext from "../../structures/CommandContext";
-import { Guild, GuildMember, Message, Snowflake } from "discord.js";
+import { Message, Snowflake } from "discord.js";
 import { NonDigits, UserMentionAndID } from "../../utils/Regex";
 import { massCommandSleep } from "../../Config";
 import InfractionsManager from "../../utils/managers/InfractionsManager";
@@ -56,6 +56,8 @@ export default class extends Command {
 			setTimeout(() => msg.delete(), (args.length - 0.5) * massCommandSleep);
 		});
 
+		if (!context.guild?.id || !context.member) return;
+
 		for (let i = 0; i < targets.length; i++) {
 			if (targets[i] === undefined) continue;
 			await this.client.bulbutils.sleep(massCommandSleep);
@@ -84,10 +86,10 @@ export default class extends Command {
 
 			const infID = await infractionsManager.unban(
 				this.client,
-				<Guild>context.guild,
+				context.guild,
 				BanType.MANUAL,
 				target,
-				<GuildMember>context.member,
+				context.member,
 				await this.client.bulbutils.translate("global_mod_action_log", context.guild?.id, {
 					action: await this.client.bulbutils.translate("mod_action_types.unban", context.guild?.id, {}),
 					moderator: context.author,

--- a/src/commands/Moderation/multiunban.ts
+++ b/src/commands/Moderation/multiunban.ts
@@ -66,8 +66,8 @@ export default class extends Command {
 			const target = await this.client.bulbfetch.getUser(targetID);
 			if (!target) {
 				await context.channel.send(
-					await this.client.bulbutils.translate("global_not_found", context.guild?.id, {
-						type: await this.client.bulbutils.translate("global_not_found_types.user", context.guild?.id, {}),
+					await this.client.bulbutils.translate("global_not_found", context.guild.id, {
+						type: await this.client.bulbutils.translate("global_not_found_types.user", context.guild.id, {}),
 						arg_expected: "user:User",
 						arg_provided: targets[i],
 						usage: this.usage,
@@ -76,11 +76,11 @@ export default class extends Command {
 				continue;
 			}
 
-			const banList = await context.guild?.bans.fetch();
-			const bannedUser = banList?.find((user) => user.user.id === targetID);
+			const banList = await context.guild.bans.fetch();
+			const bannedUser = banList.find((user) => user.user.id === targetID);
 
 			if (!bannedUser) {
-				context.channel.send(await this.client.bulbutils.translate("not_banned", context.guild?.id, { target }));
+				context.channel.send(await this.client.bulbutils.translate("not_banned", context.guild.id, { target }));
 				continue;
 			}
 
@@ -90,8 +90,8 @@ export default class extends Command {
 				BanType.MANUAL,
 				target,
 				context.member,
-				await this.client.bulbutils.translate("global_mod_action_log", context.guild?.id, {
-					action: await this.client.bulbutils.translate("mod_action_types.unban", context.guild?.id, {}),
+				await this.client.bulbutils.translate("global_mod_action_log", context.guild.id, {
+					action: await this.client.bulbutils.translate("mod_action_types.unban", context.guild.id, {}),
 					moderator: context.author,
 					target,
 					reason,
@@ -105,8 +105,8 @@ export default class extends Command {
 		if (!fullList.length) return;
 
 		return context.channel.send(
-			await this.client.bulbutils.translate("action_success_multi", context.guild?.id, {
-				action: await this.client.bulbutils.translate("mod_action_types.unban", context.guild?.id, {}),
+			await this.client.bulbutils.translate("action_success_multi", context.guild.id, {
+				action: await this.client.bulbutils.translate("mod_action_types.unban", context.guild.id, {}),
 				full_list: fullList.join(", "),
 				reason,
 			}),

--- a/src/commands/Moderation/multiwarn.ts
+++ b/src/commands/Moderation/multiwarn.ts
@@ -1,6 +1,6 @@
 import Command from "../../structures/Command";
 import CommandContext from "../../structures/CommandContext";
-import { GuildMember, Message, Snowflake } from "discord.js";
+import { GuildMember, Message } from "discord.js";
 import { NonDigits, UserMentionAndID } from "../../utils/Regex";
 import InfractionsManager from "../../utils/managers/InfractionsManager";
 import BulbBotClient from "../../structures/BulbBotClient";
@@ -48,6 +48,8 @@ export default class extends Command {
 			return await this.client.commands.get("warn")?.run(context, args);
 		}
 
+		if (!context.guild?.id || !context.member) return;
+
 		for (let i = 0; i < targets.length; i++) {
 			if (targets[i] === undefined) continue;
 
@@ -69,9 +71,9 @@ export default class extends Command {
 
 			const infID = await infractionsManager.warn(
 				this.client,
-				<Snowflake>context.guild?.id,
+				context.guild?.id,
 				target.user,
-				<GuildMember>context.member,
+				context.member,
 				await this.client.bulbutils.translate("global_mod_action_log", context.guild?.id, {
 					action: await this.client.bulbutils.translate("mod_action_types.warn", context.guild?.id, {}),
 					moderator: context.author,

--- a/src/commands/Moderation/multiwarn.ts
+++ b/src/commands/Moderation/multiwarn.ts
@@ -34,7 +34,7 @@ export default class extends Command {
 				}),
 			);
 
-		let reason: string = args.slice(targets?.length).join(" ").replace(UserMentionAndID, "");
+		let reason: string = args.slice(targets.length).join(" ").replace(UserMentionAndID, "");
 
 		if (reason === "") reason = await this.client.bulbutils.translate("global_no_reason", context.guild?.id, {});
 		const fullList: string[] = [];
@@ -54,12 +54,12 @@ export default class extends Command {
 			if (targets[i] === undefined) continue;
 
 			const t: string = targets[i].replace(NonDigits, "");
-			const target: GuildMember | undefined = await this.client.bulbfetch.getGuildMember(context.guild?.members, t);
+			const target: GuildMember | undefined = await this.client.bulbfetch.getGuildMember(context.guild.members, t);
 
 			if (!target) {
 				await context.channel.send(
-					await this.client.bulbutils.translate("global_not_found", context.guild?.id, {
-						type: await this.client.bulbutils.translate("global_not_found_types.member", context.guild?.id, {}),
+					await this.client.bulbutils.translate("global_not_found", context.guild.id, {
+						type: await this.client.bulbutils.translate("global_not_found_types.member", context.guild.id, {}),
 						arg_expected: "member:Member",
 						arg_provided: t,
 						usage: this.usage,
@@ -71,11 +71,11 @@ export default class extends Command {
 
 			const infID = await infractionsManager.warn(
 				this.client,
-				context.guild?.id,
+				context.guild.id,
 				target.user,
 				context.member,
-				await this.client.bulbutils.translate("global_mod_action_log", context.guild?.id, {
-					action: await this.client.bulbutils.translate("mod_action_types.warn", context.guild?.id, {}),
+				await this.client.bulbutils.translate("global_mod_action_log", context.guild.id, {
+					action: await this.client.bulbutils.translate("mod_action_types.warn", context.guild.id, {}),
 					moderator: context.author,
 					target: target.user,
 					reason,
@@ -89,8 +89,8 @@ export default class extends Command {
 		if (!fullList.length) return;
 
 		return context.channel.send(
-			await this.client.bulbutils.translate("action_success_multi", context.guild?.id, {
-				action: await this.client.bulbutils.translate("mod_action_types.warn", context.guild?.id, {}),
+			await this.client.bulbutils.translate("action_success_multi", context.guild.id, {
+				action: await this.client.bulbutils.translate("mod_action_types.warn", context.guild.id, {}),
 				full_list: fullList.join(", "),
 				reason,
 			}),

--- a/src/commands/Moderation/multiwarn.ts
+++ b/src/commands/Moderation/multiwarn.ts
@@ -24,7 +24,7 @@ export default class extends Command {
 	}
 
 	public async run(context: CommandContext, args: string[]): Promise<void | Message> {
-		let targets: RegExpMatchArray = <RegExpMatchArray>args.slice(0).join(" ").match(UserMentionAndID);
+		let targets: RegExpMatchArray = args.slice(0).join(" ").match(UserMentionAndID) || [];
 		targets = [...new Set(targets.map((target) => target.replace(NonDigits, "")))];
 
 		if (!targets.length)
@@ -39,19 +39,19 @@ export default class extends Command {
 		if (reason === "") reason = await this.client.bulbutils.translate("global_no_reason", context.guild?.id, {});
 		const fullList: string[] = [];
 
-		if (targets!.length <= 1) {
+		if (targets.length <= 1) {
 			await context.channel.send(
 				await this.client.bulbutils.translate("action_multi_less_than_2", context.guild?.id, {
 					action: await this.client.bulbutils.translate("action_multi_types.warn", context.guild?.id, {}),
 				}),
 			);
-			return await this.client.commands.get("warn")!.run(context, args);
+			return await this.client.commands.get("warn")?.run(context, args);
 		}
 
-		for (let i = 0; i < targets!.length; i++) {
-			if (targets![i] === undefined) continue;
+		for (let i = 0; i < targets.length; i++) {
+			if (targets[i] === undefined) continue;
 
-			const t: string = targets![i].replace(NonDigits, "");
+			const t: string = targets[i].replace(NonDigits, "");
 			const target: GuildMember | undefined = await this.client.bulbfetch.getGuildMember(context.guild?.members, t);
 
 			if (!target) {

--- a/src/commands/Moderation/mute.ts
+++ b/src/commands/Moderation/mute.ts
@@ -46,10 +46,10 @@ export default class extends Command {
 			);
 		if (!context.guild || !context.member || (await this.client.bulbutils.resolveUserHandle(context, this.client.bulbutils.checkUser(context, target), target.user))) return;
 
-		if (!reason) reason = await this.client.bulbutils.translate("global_no_reason", context.guild?.id, {});
-		if ((duration && duration <= parse("0s")) || duration === null) return context.channel.send(await this.client.bulbutils.translate("duration_invalid_0s", context.guild?.id, {}));
-		if (duration > parse("28d")) return context.channel.send(await this.client.bulbutils.translate("duration_invalid_28d", context.guild?.id, {}));
-		if (target.communicationDisabledUntilTimestamp !== null) return context.channel.send(await this.client.bulbutils.translate("mute_already_muted", context.guild?.id, { target: target.user }));
+		if (!reason) reason = await this.client.bulbutils.translate("global_no_reason", context.guild.id, {});
+		if ((duration && duration <= parse("0s")) || duration === null) return context.channel.send(await this.client.bulbutils.translate("duration_invalid_0s", context.guild.id, {}));
+		if (duration > parse("28d")) return context.channel.send(await this.client.bulbutils.translate("duration_invalid_28d", context.guild.id, {}));
+		if (target.communicationDisabledUntilTimestamp !== null) return context.channel.send(await this.client.bulbutils.translate("mute_already_muted", context.guild.id, { target: target.user }));
 
 		const infID = await infractionsManager.mute(
 			this.client,

--- a/src/commands/Moderation/mute.ts
+++ b/src/commands/Moderation/mute.ts
@@ -1,6 +1,6 @@
 import Command from "../../structures/Command";
 import CommandContext from "../../structures/CommandContext";
-import { Guild, GuildMember, Message, Snowflake } from "discord.js";
+import { GuildMember, Message, Snowflake } from "discord.js";
 import { NonDigits } from "../../utils/Regex";
 import DatabaseManager from "../../utils/managers/DatabaseManager";
 import parse from "parse-duration";
@@ -32,7 +32,7 @@ export default class extends Command {
 	async run(context: CommandContext, args: string[]): Promise<void | Message> {
 		const targetID: Snowflake = args[0].replace(NonDigits, "");
 		const target: GuildMember | undefined = await this.client.bulbfetch.getGuildMember(context.guild?.members, targetID);
-		const duration: number = <number>parse(args[1]);
+		const duration: number = parse(args[1]);
 		let reason: string = args.slice(2).join(" ");
 
 		if (!target)
@@ -44,37 +44,37 @@ export default class extends Command {
 					usage: this.usage,
 				}),
 			);
-		if (await this.client.bulbutils.resolveUserHandle(context, this.client.bulbutils.checkUser(context, target), target.user)) return;
+		if (!context.guild || !context.member || (await this.client.bulbutils.resolveUserHandle(context, this.client.bulbutils.checkUser(context, target), target.user))) return;
 
 		if (!reason) reason = await this.client.bulbutils.translate("global_no_reason", context.guild?.id, {});
-		if ((duration && duration <= <number>parse("0s")) || duration === null) return context.channel.send(await this.client.bulbutils.translate("duration_invalid_0s", context.guild?.id, {}));
-		if (duration > <number>parse("28d")) return context.channel.send(await this.client.bulbutils.translate("duration_invalid_28d", context.guild?.id, {}));
+		if ((duration && duration <= parse("0s")) || duration === null) return context.channel.send(await this.client.bulbutils.translate("duration_invalid_0s", context.guild?.id, {}));
+		if (duration > parse("28d")) return context.channel.send(await this.client.bulbutils.translate("duration_invalid_28d", context.guild?.id, {}));
 		if (target.communicationDisabledUntilTimestamp !== null) return context.channel.send(await this.client.bulbutils.translate("mute_already_muted", context.guild?.id, { target: target.user }));
 
 		const infID = await infractionsManager.mute(
 			this.client,
-			<Guild>context.guild,
+			context.guild,
 			target,
-			<GuildMember>context.member,
-			await this.client.bulbutils.translate("global_mod_action_log", context.guild?.id, {
-				action: await this.client.bulbutils.translate("mod_action_types.mute", context.guild?.id, {}),
+			context.member,
+			await this.client.bulbutils.translate("global_mod_action_log", context.guild.id, {
+				action: await this.client.bulbutils.translate("mod_action_types.mute", context.guild.id, {}),
 				moderator: context.author,
 				target: target.user,
 				reason,
-				until: Date.now() + <number>parse(args[1]),
+				until: Date.now() + parse(args[1]),
 			}),
 			reason,
-			Date.now() + <number>parse(args[1]),
+			Date.now() + parse(args[1]),
 		);
 
-		const timezone = this.client.bulbutils.timezones[await databaseManager.getTimezone(<Snowflake>context.guild?.id)];
+		const timezone = this.client.bulbutils.timezones[await databaseManager.getTimezone(context.guild.id)];
 		await context.channel.send(
-			await this.client.bulbutils.translate("action_success_temp", context.guild?.id, {
-				action: await this.client.bulbutils.translate("mod_action_types.mute", context.guild?.id, {}),
+			await this.client.bulbutils.translate("action_success_temp", context.guild.id, {
+				action: await this.client.bulbutils.translate("mod_action_types.mute", context.guild.id, {}),
 				target: target.user,
 				reason,
 				infraction_id: infID,
-				until: moment(Date.now() + <number>parse(args[1]))
+				until: moment(Date.now() + parse(args[1]))
 					.tz(timezone)
 					.format("MMM Do YYYY, h:mm:ssa z"),
 			}),

--- a/src/commands/Moderation/nickname.ts
+++ b/src/commands/Moderation/nickname.ts
@@ -1,6 +1,6 @@
 import Command from "../../structures/Command";
 import CommandContext from "../../structures/CommandContext";
-import { Guild, GuildMember, Message, Snowflake } from "discord.js";
+import { GuildMember, Message, Snowflake } from "discord.js";
 import { QuoteMarked, UserMentionAndID } from "../../utils/Regex";
 import InfractionsManager from "../../utils/managers/InfractionsManager";
 import BulbBotClient from "../../structures/BulbBotClient";
@@ -27,7 +27,7 @@ export default class extends Command {
 	public async run(context: CommandContext, args: string[]): Promise<void | Message> {
 		const argString: string = args.slice(1).join(" ");
 		UserMentionAndID.lastIndex = 0;
-		const match: RegExpMatchArray = <RegExpMatchArray>UserMentionAndID.exec(args[0]);
+		const match = UserMentionAndID.exec(args[0]);
 		if (!match)
 			return context.channel.send(
 				await this.client.bulbutils.translate("global_not_found", context.guild?.id, {
@@ -39,7 +39,7 @@ export default class extends Command {
 			);
 		const targetID: Snowflake = match[1] ?? match[2];
 		const target: GuildMember | undefined = await this.client.bulbfetch.getGuildMember(context.guild?.members, targetID);
-		const nickmatch: RegExpMatchArray = <RegExpMatchArray>QuoteMarked.exec(argString);
+		const nickmatch = QuoteMarked.exec(argString);
 		const nickname: string = (nickmatch ? nickmatch[1] : args[1])?.trim() ?? "";
 		const reason: string =
 			args
@@ -62,14 +62,16 @@ export default class extends Command {
 		if (nickname === target.nickname)
 			return context.channel.send(await this.client.bulbutils.translate("nickname_same_nickname", context.guild?.id, { target: target.user, nickname: target.nickname }));
 
+		if (!context.guild || !context.member) return;
+
 		const nickOld: string = target.nickname || target.user.username;
 		let infID: number;
 		try {
 			infID = await infractionsManager.nickname(
 				this.client,
-				<Guild>context.guild,
+				context.guild,
 				target,
-				<GuildMember>context.member,
+				context.member,
 				await this.client.bulbutils.translate("global_mod_action_log", context.guild?.id, {
 					action: nickname ? "Nickname changed" : "Nickname removed",
 					moderator: context.author,

--- a/src/commands/Moderation/nickname.ts
+++ b/src/commands/Moderation/nickname.ts
@@ -40,7 +40,7 @@ export default class extends Command {
 		const targetID: Snowflake = match[1] ?? match[2];
 		const target: GuildMember | undefined = await this.client.bulbfetch.getGuildMember(context.guild?.members, targetID);
 		const nickmatch = QuoteMarked.exec(argString);
-		const nickname: string = (nickmatch ? nickmatch[1] : args[1])?.trim() ?? "";
+		const nickname: string = (nickmatch ? nickmatch[1] : args[1]).trim() ?? "";
 		const reason: string =
 			args
 				.slice(1 + nickname.split(" ").length)
@@ -72,7 +72,7 @@ export default class extends Command {
 				context.guild,
 				target,
 				context.member,
-				await this.client.bulbutils.translate("global_mod_action_log", context.guild?.id, {
+				await this.client.bulbutils.translate("global_mod_action_log", context.guild.id, {
 					action: nickname ? "Nickname changed" : "Nickname removed",
 					moderator: context.author,
 					target: target.user,
@@ -84,11 +84,11 @@ export default class extends Command {
 			);
 		} catch (e: any) {
 			console.error(e.stack);
-			return context.channel.send(await this.client.bulbutils.translate("nickname_fail", context.guild?.id, { target: target.user }));
+			return context.channel.send(await this.client.bulbutils.translate("nickname_fail", context.guild.id, { target: target.user }));
 		}
 
 		return context.channel.send(
-			await this.client.bulbutils.translate(nickname ? "nickname_success" : "nickname_remove_success", context.guild?.id, {
+			await this.client.bulbutils.translate(nickname ? "nickname_success" : "nickname_remove_success", context.guild.id, {
 				target: target.user,
 				nick_old: nickOld,
 				nick_new: nickname,

--- a/src/commands/Moderation/prune.ts
+++ b/src/commands/Moderation/prune.ts
@@ -26,9 +26,12 @@ export default class extends Command {
 	public async run(context: CommandContext, args: string[]): Promise<void | Message> {
 		const days = parseInt(args[0]);
 		if (isNaN(days) || days <= 0 || days > 30) return context.channel.send(await this.client.bulbutils.translate("prune_invalid_time", context.guild?.id, {}));
-		let roles: RegExpMatchArray = <RegExpMatchArray>args.slice(1).join(" ").match(RoleMentionAndID);
-		if (roles === null) roles = [];
-		else roles = roles.map((r) => r.replace(NonDigits, ""));
+		const roles =
+			args
+				.slice(1)
+				.join(" ")
+				.match(RoleMentionAndID)
+				?.map((r) => r.replace(NonDigits, "")) ?? [];
 
 		let reason: string = args
 			.slice(roles.length + 1)

--- a/src/commands/Moderation/prune.ts
+++ b/src/commands/Moderation/prune.ts
@@ -77,7 +77,7 @@ export default class extends Command {
 				});
 				await sendModActionPreformatted(
 					this.client,
-					context.guild!,
+					context.guild,
 					await this.client.bulbutils.translate("prune_log", context.guild?.id, {
 						user: context.author,
 						prune,

--- a/src/commands/Moderation/purge/all.ts
+++ b/src/commands/Moderation/purge/all.ts
@@ -1,11 +1,12 @@
 import Command from "../../../structures/Command";
 import SubCommand from "../../../structures/SubCommand";
 import CommandContext from "../../../structures/CommandContext";
-import { Collection, Guild, Message, TextChannel } from "discord.js";
+import { Collection, Message } from "discord.js";
 import moment from "moment";
 import { writeFileSync } from "fs";
 import LoggingManager from "../../../utils/managers/LoggingManager";
 import BulbBotClient from "../../../structures/BulbBotClient";
+import { isGuildChannel } from "../../../utils/typechecks";
 
 const loggingManager: LoggingManager = new LoggingManager();
 
@@ -26,6 +27,8 @@ export default class extends SubCommand {
 		let amount = Number(args[0]);
 		if (Number(amount) >= 500) return await context.channel.send(await this.client.bulbutils.translate("purge_too_many", context.guild?.id, {}));
 		if (Number(amount) < 2 || isNaN(amount)) return await context.channel.send(await this.client.bulbutils.translate("purge_too_few", context.guild?.id, {}));
+		if (!isGuildChannel(context.channel)) return;
+
 		const deleteMsg: number[] = [];
 		let a = 0;
 
@@ -37,9 +40,7 @@ export default class extends SubCommand {
 		}
 		if (amount - a !== 0) deleteMsg.push(amount - a);
 
-		let delMsgs = `Message purge in #${(<TextChannel>context.channel).name} (${context.channel.id}) by ${context.author.tag} (${context.author.id}) at ${moment().format(
-			"MMMM Do YYYY, h:mm:ss a",
-		)} \n`;
+		let delMsgs = `Message purge in #${context.channel.name} (${context.channel.id}) by ${context.author.tag} (${context.author.id}) at ${moment().format("MMMM Do YYYY, h:mm:ss a")} \n`;
 
 		const twoWeeksAgo = moment().subtract(14, "days").unix();
 
@@ -55,11 +56,11 @@ export default class extends SubCommand {
 
 			amount = msgs.size;
 
-			await (<TextChannel>context.channel).bulkDelete(msgs);
+			await context.channel.bulkDelete(msgs);
 		}
 
 		writeFileSync(`${__dirname}/../../../../files/PURGE-${context.guild?.id}.txt`, delMsgs);
-		await loggingManager.sendModActionFile(this.client, <Guild>context.guild, "purge", amount, `${__dirname}/../../../../files/PURGE-${context.guild?.id}.txt`, context.channel, context.author);
+		await loggingManager.sendModActionFile(this.client, context.guild, "purge", amount, `${__dirname}/../../../../files/PURGE-${context.guild?.id}.txt`, context.channel, context.author);
 
 		await context.channel.send(await this.client.bulbutils.translate("purge_success", context.guild?.id, { count: amount }));
 	}

--- a/src/commands/Moderation/purge/between.ts
+++ b/src/commands/Moderation/purge/between.ts
@@ -1,11 +1,12 @@
 import Command from "../../../structures/Command";
 import SubCommand from "../../../structures/SubCommand";
 import CommandContext from "../../../structures/CommandContext";
-import { Collection, Guild, Message, Snowflake, TextChannel } from "discord.js";
+import { Collection, Message, Snowflake } from "discord.js";
 import moment from "moment";
 import { writeFileSync } from "fs";
 import LoggingManager from "../../../utils/managers/LoggingManager";
 import BulbBotClient from "../../../structures/BulbBotClient";
+import { isGuildChannel } from "../../../utils/typechecks";
 
 const loggingManager: LoggingManager = new LoggingManager();
 
@@ -23,12 +24,12 @@ export default class extends SubCommand {
 	}
 
 	public async run(context: CommandContext, args: string[]): Promise<void | Message> {
+		if (!isGuildChannel(context.channel)) return;
+
 		const msgs: Collection<string, Message> = await context.channel.messages.fetch({ limit: 100 });
 		const allMessages: Message[] = msgs.map((m) => m).reverse();
 		const messages: Snowflake[] = [];
-		let delMsgs = `Message purge in #${(<TextChannel>context.channel).name} (${context.channel.id}) by ${context.author.tag} (${context.author.id}) at ${moment().format(
-			"MMMM Do YYYY, h:mm:ss a",
-		)} \n`;
+		let delMsgs = `Message purge in #${context.channel.name} (${context.channel.id}) by ${context.author.tag} (${context.author.id}) at ${moment().format("MMMM Do YYYY, h:mm:ss a")} \n`;
 
 		let counting = false;
 		const twoWeeksAgo = moment().subtract(14, "days").unix();
@@ -47,19 +48,11 @@ export default class extends SubCommand {
 			if (msg.id === args[1]) counting = false;
 		}
 
-		await (<TextChannel>context.channel).bulkDelete(messages);
+		await context.channel.bulkDelete(messages);
 
 		writeFileSync(`${__dirname}/../../../../files/PURGE-${context.guild?.id}.txt`, delMsgs);
 
-		await loggingManager.sendModActionFile(
-			this.client,
-			<Guild>context.guild,
-			"purge",
-			messages.length,
-			`${__dirname}/../../../../files/PURGE-${context.guild?.id}.txt`,
-			context.channel,
-			context.author,
-		);
+		await loggingManager.sendModActionFile(this.client, context.guild, "purge", messages.length, `${__dirname}/../../../../files/PURGE-${context.guild?.id}.txt`, context.channel, context.author);
 
 		await context.channel.send(await this.client.bulbutils.translate("purge_success", context.guild?.id, { count: messages.length }));
 	}

--- a/src/commands/Moderation/purge/contains.ts
+++ b/src/commands/Moderation/purge/contains.ts
@@ -1,11 +1,12 @@
 import Command from "../../../structures/Command";
 import SubCommand from "../../../structures/SubCommand";
 import CommandContext from "../../../structures/CommandContext";
-import { Collection, Guild, Message, Snowflake, TextChannel } from "discord.js";
+import { Collection, Message, Snowflake } from "discord.js";
 import moment from "moment";
 import { writeFileSync } from "fs";
 import LoggingManager from "../../../utils/managers/LoggingManager";
 import BulbBotClient from "../../../structures/BulbBotClient";
+import { isGuildChannel } from "../../../utils/typechecks";
 
 const loggingManager: LoggingManager = new LoggingManager();
 
@@ -26,6 +27,7 @@ export default class extends SubCommand {
 		let amount = Number(args[1]);
 		if (amount >= 500) return context.channel.send(await this.client.bulbutils.translate("purge_too_many", context.guild?.id, {}));
 		if (amount < 2 || isNaN(amount)) return context.channel.send(await this.client.bulbutils.translate("purge_too_few", context.guild?.id, {}));
+		if (!isGuildChannel(context.channel)) return;
 
 		const deleteMsg: number[] = [];
 		let a = 0;
@@ -38,9 +40,7 @@ export default class extends SubCommand {
 		}
 		if (amount - a !== 0) deleteMsg.push(amount - a);
 
-		let delMsgs = `Message purge in #${(<TextChannel>context.channel).name} (${context.channel.id}) by ${context.author.tag} (${context.author.id}) at ${moment().format(
-			"MMMM Do YYYY, h:mm:ss a",
-		)} \n`;
+		let delMsgs = `Message purge in #${context.channel.name} (${context.channel.id}) by ${context.author.tag} (${context.author.id}) at ${moment().format("MMMM Do YYYY, h:mm:ss a")} \n`;
 
 		const messagesToPurge: Snowflake[] = [];
 		amount = 0;
@@ -63,11 +63,11 @@ export default class extends SubCommand {
 			});
 		}
 
-		await (<TextChannel>context.channel).bulkDelete(messagesToPurge);
+		await context.channel.bulkDelete(messagesToPurge);
 
 		writeFileSync(`${__dirname}/../../../../files/PURGE-${context.guild?.id}.txt`, delMsgs);
 
-		await loggingManager.sendModActionFile(this.client, <Guild>context.guild, "purge", amount, `${__dirname}/../../../../files/PURGE-${context.guild?.id}.txt`, context.channel, context.author);
+		await loggingManager.sendModActionFile(this.client, context.guild, "purge", amount, `${__dirname}/../../../../files/PURGE-${context.guild?.id}.txt`, context.channel, context.author);
 
 		await context.channel.send(await this.client.bulbutils.translate("purge_success", context.guild?.id, { count: amount }));
 	}

--- a/src/commands/Moderation/purge/emojis.ts
+++ b/src/commands/Moderation/purge/emojis.ts
@@ -1,12 +1,13 @@
 import Command from "../../../structures/Command";
 import SubCommand from "../../../structures/SubCommand";
 import CommandContext from "../../../structures/CommandContext";
-import { Collection, Guild, Message, Snowflake, TextChannel } from "discord.js";
+import { Collection, Message, Snowflake } from "discord.js";
 import moment from "moment";
 import { CustomEmote, Emoji } from "../../../utils/Regex";
 import { writeFileSync } from "fs";
 import LoggingManager from "../../../utils/managers/LoggingManager";
 import BulbBotClient from "../../../structures/BulbBotClient";
+import { isGuildChannel } from "../../../utils/typechecks";
 
 const loggingManager: LoggingManager = new LoggingManager();
 
@@ -27,6 +28,7 @@ export default class extends SubCommand {
 		let amount = Number(args[0]);
 		if (amount >= 500) return context.channel.send(await this.client.bulbutils.translate("purge_too_many", context.guild?.id, {}));
 		if (amount < 2 || isNaN(amount)) return context.channel.send(await this.client.bulbutils.translate("purge_too_few", context.guild?.id, {}));
+		if (!isGuildChannel(context.channel)) return;
 
 		const deleteMsg: number[] = [];
 		let a = 0;
@@ -39,9 +41,7 @@ export default class extends SubCommand {
 		}
 		if (amount - a !== 0) deleteMsg.push(amount - a);
 
-		let delMsgs = `Message purge in #${(<TextChannel>context.channel).name} (${context.channel.id}) by ${context.author.tag} (${context.author.id}) at ${moment().format(
-			"MMMM Do YYYY, h:mm:ss a",
-		)} \n`;
+		let delMsgs = `Message purge in #${context.channel.name} (${context.channel.id}) by ${context.author.tag} (${context.author.id}) at ${moment().format("MMMM Do YYYY, h:mm:ss a")} \n`;
 
 		const messagesToPurge: Snowflake[] = [];
 		amount = 0;
@@ -63,11 +63,11 @@ export default class extends SubCommand {
 			});
 		}
 
-		await (<TextChannel>context.channel).bulkDelete(messagesToPurge);
+		await context.channel.bulkDelete(messagesToPurge);
 
 		writeFileSync(`${__dirname}/../../../../files/PURGE-${context.guild?.id}.txt`, delMsgs);
 
-		await loggingManager.sendModActionFile(this.client, <Guild>context.guild, "purge", amount, `${__dirname}/../../../../files/PURGE-${context.guild?.id}.txt`, context.channel, context.author);
+		await loggingManager.sendModActionFile(this.client, context.guild, "purge", amount, `${__dirname}/../../../../files/PURGE-${context.guild?.id}.txt`, context.channel, context.author);
 
 		await context.channel.send(await this.client.bulbutils.translate("purge_success", context.guild?.id, { count: amount }));
 	}

--- a/src/commands/Moderation/slowmode.ts
+++ b/src/commands/Moderation/slowmode.ts
@@ -1,9 +1,10 @@
 import Command from "../../structures/Command";
 import CommandContext from "../../structures/CommandContext";
-import { Message, Snowflake, TextChannel } from "discord.js";
+import { Message, Snowflake } from "discord.js";
 import { NonDigits } from "../../utils/Regex";
 import parse from "parse-duration";
 import BulbBotClient from "../../structures/BulbBotClient";
+import { isTextChannel } from "../../utils/typechecks";
 
 export default class extends Command {
 	constructor(client: BulbBotClient, name: string) {
@@ -27,9 +28,9 @@ export default class extends Command {
 		let targetChannel: Snowflake;
 		if (!args[1]) targetChannel = context.channel.id;
 		else targetChannel = args[1].replace(NonDigits, "");
-		const channel: TextChannel = <TextChannel>await this.client.bulbfetch.getChannel(context.guild?.channels, targetChannel);
+		const channel = await this.client.bulbfetch.getChannel(context.guild?.channels, targetChannel);
 
-		if (!channel || channel.type !== "GUILD_TEXT") {
+		if (!channel || channel.type !== "GUILD_TEXT" || !isTextChannel(channel)) {
 			return context.channel.send(
 				await this.client.bulbutils.translate("global_not_found", context.guild?.id, {
 					type: await this.client.bulbutils.translate("global_not_found_types.channel", context.guild?.id, {}),
@@ -39,11 +40,11 @@ export default class extends Command {
 				}),
 			);
 		}
-		if (args.length === 1) duration = <number>parse(args[0]);
-		else duration = <number>parse(args[0]);
+		if (args.length === 1) duration = parse(args[0]);
+		else duration = parse(args[0]);
 
-		if (duration < <number>parse("0s") || duration === null) return context.channel.send(await this.client.bulbutils.translate("duration_invalid_0s", context.guild?.id, {}));
-		if (duration > <number>parse("6h")) return context.channel.send(await this.client.bulbutils.translate("duration_invalid_6h", context.guild?.id, {}));
+		if (duration < parse("0s") || duration === null) return context.channel.send(await this.client.bulbutils.translate("duration_invalid_0s", context.guild?.id, {}));
+		if (duration > parse("6h")) return context.channel.send(await this.client.bulbutils.translate("duration_invalid_6h", context.guild?.id, {}));
 
 		try {
 			await channel.setRateLimitPerUser(duration / 1000);

--- a/src/commands/Moderation/softban.ts
+++ b/src/commands/Moderation/softban.ts
@@ -53,7 +53,7 @@ export default class extends Command {
 			await context.channel.send(
 				await this.client.bulbutils.translate("already_banned", context.guild?.id, {
 					target: bannedUser.user,
-					reason: bannedUser.reason!.split("Reason: ").pop(),
+					reason: bannedUser.reason?.split("Reason: ").pop() || (await this.client.bulbutils.translate("global_no_reason", context.guild?.id, {})),
 				}),
 			);
 			return;

--- a/src/commands/Moderation/softban.ts
+++ b/src/commands/Moderation/softban.ts
@@ -1,6 +1,6 @@
 import Command from "../../structures/Command";
 import CommandContext from "../../structures/CommandContext";
-import { Guild, GuildMember, Snowflake } from "discord.js";
+import { GuildMember, Snowflake } from "discord.js";
 import { NonDigits } from "../../utils/Regex";
 import InfractionsManager from "../../utils/managers/InfractionsManager";
 import { BanType } from "../../utils/types/BanType";
@@ -59,12 +59,14 @@ export default class extends Command {
 			return;
 		}
 
+		if (!context.guild || !context.member) return;
+
 		const infID = await infractionsManager.ban(
 			this.client,
-			<Guild>context.guild,
+			context.guild,
 			BanType.SOFT,
 			target.user,
-			<GuildMember>context.member,
+			context.member,
 			await this.client.bulbutils.translate("global_mod_action_log", context.guild?.id, {
 				action: await this.client.bulbutils.translate("mod_action_types.soft_ban", context.guild?.id, {}),
 				moderator: context.author,

--- a/src/commands/Moderation/softban.ts
+++ b/src/commands/Moderation/softban.ts
@@ -67,8 +67,8 @@ export default class extends Command {
 			BanType.SOFT,
 			target.user,
 			context.member,
-			await this.client.bulbutils.translate("global_mod_action_log", context.guild?.id, {
-				action: await this.client.bulbutils.translate("mod_action_types.soft_ban", context.guild?.id, {}),
+			await this.client.bulbutils.translate("global_mod_action_log", context.guild.id, {
+				action: await this.client.bulbutils.translate("mod_action_types.soft_ban", context.guild.id, {}),
 				moderator: context.author,
 				target: target.user,
 				reason,
@@ -77,8 +77,8 @@ export default class extends Command {
 		);
 
 		await context.channel.send(
-			await this.client.bulbutils.translate("action_success", context.guild?.id, {
-				action: await this.client.bulbutils.translate("mod_action_types.soft_ban", context.guild?.id, {}),
+			await this.client.bulbutils.translate("action_success", context.guild.id, {
+				action: await this.client.bulbutils.translate("mod_action_types.soft_ban", context.guild.id, {}),
 				target: target.user,
 				reason,
 				infraction_id: infID,

--- a/src/commands/Moderation/tempban.ts
+++ b/src/commands/Moderation/tempban.ts
@@ -62,8 +62,8 @@ export default class extends Command {
 			context.guild,
 			target,
 			context.member,
-			await this.client.bulbutils.translate("global_mod_action_log", context.guild?.id, {
-				action: await this.client.bulbutils.translate("mod_action_types.temp_ban", context.guild?.id, {}),
+			await this.client.bulbutils.translate("global_mod_action_log", context.guild.id, {
+				action: await this.client.bulbutils.translate("mod_action_types.temp_ban", context.guild.id, {}),
 				moderator: context.author,
 				target: target.user,
 				reason,

--- a/src/commands/Moderation/tempban.ts
+++ b/src/commands/Moderation/tempban.ts
@@ -1,7 +1,7 @@
 import BulbBotClient from "../../structures/BulbBotClient";
 import Command from "../../structures/Command";
 import CommandContext from "../../structures/CommandContext";
-import { Guild, GuildMember, Message, Snowflake } from "discord.js";
+import { GuildMember, Message, Snowflake } from "discord.js";
 import { NonDigits } from "../../utils/Regex";
 import parse from "parse-duration";
 import InfractionsManager from "../../utils/managers/InfractionsManager";
@@ -36,7 +36,7 @@ export default class extends Command {
 	public async run(context: CommandContext, args: string[]): Promise<void | Message> {
 		const targetID: Snowflake = args[0].replace(NonDigits, "");
 		const target: GuildMember | undefined = await this.client.bulbfetch.getGuildMember(context.guild?.members, targetID);
-		const duration: number = <number>parse(args[1]);
+		const duration: number = parse(args[1]);
 		let reason: string = args.slice(2).join(" ");
 		let infID: number | null;
 
@@ -52,28 +52,30 @@ export default class extends Command {
 		if (await this.client.bulbutils.resolveUserHandle(context, this.client.bulbutils.checkUser(context, target), target.user)) return;
 
 		if (!reason) reason = await this.client.bulbutils.translate("global_no_reason", context.guild?.id, {});
-		if ((duration && duration <= <number>parse("0s")) || duration === null) return context.channel.send(await this.client.bulbutils.translate("duration_invalid_0s", context.guild?.id, {}));
-		if (duration > <number>parse("1y")) return context.channel.send(await this.client.bulbutils.translate("duration_invalid_1y", context.guild?.id, {}));
+		if ((duration && duration <= parse("0s")) || duration === null) return context.channel.send(await this.client.bulbutils.translate("duration_invalid_0s", context.guild?.id, {}));
+		if (duration > parse("1y")) return context.channel.send(await this.client.bulbutils.translate("duration_invalid_1y", context.guild?.id, {}));
+
+		if (!context.guild?.id || !context.member) return;
 
 		infID = await infractionsManager.tempban(
 			this.client,
-			<Guild>context.guild,
+			context.guild,
 			target,
-			<GuildMember>context.member,
+			context.member,
 			await this.client.bulbutils.translate("global_mod_action_log", context.guild?.id, {
 				action: await this.client.bulbutils.translate("mod_action_types.temp_ban", context.guild?.id, {}),
 				moderator: context.author,
 				target: target.user,
 				reason,
-				until: Date.now() + <number>parse(args[1]),
+				until: Date.now() + parse(args[1]),
 			}),
 			reason,
-			Date.now() + <number>parse(args[1]),
+			Date.now() + parse(args[1]),
 		);
 
-		if (infID === null || !context.guild?.id) return;
+		if (infID === null) return;
 
-		await createTempBan(target, reason, Date.now() + <number>parse(args[1]), context.guild.id);
+		await createTempBan(target, reason, Date.now() + parse(args[1]), context.guild.id);
 		const tempban: any = await getLatestTempBan(target, context.guild.id);
 
 		const timezone = this.client.bulbutils.timezones[await databaseManager.getTimezone(context.guild.id)];
@@ -83,7 +85,7 @@ export default class extends Command {
 				target: target.user,
 				reason,
 				infraction_id: infID,
-				until: moment(Date.now() + <number>parse(args[1]))
+				until: moment(Date.now() + parse(args[1]))
 					.tz(timezone)
 					.format("MMM Do YYYY, h:mm:ssa z"),
 			}),

--- a/src/commands/Moderation/tempban.ts
+++ b/src/commands/Moderation/tempban.ts
@@ -71,15 +71,15 @@ export default class extends Command {
 			Date.now() + <number>parse(args[1]),
 		);
 
-		if (infID === null) return;
+		if (infID === null || !context.guild?.id) return;
 
-		await createTempBan(target, reason, Date.now() + <number>parse(args[1]), context.guild!.id);
-		const tempban: any = await getLatestTempBan(target, context.guild!.id);
+		await createTempBan(target, reason, Date.now() + <number>parse(args[1]), context.guild.id);
+		const tempban: any = await getLatestTempBan(target, context.guild.id);
 
-		const timezone = this.client.bulbutils.timezones[await databaseManager.getTimezone(<Snowflake>context.guild?.id)];
+		const timezone = this.client.bulbutils.timezones[await databaseManager.getTimezone(context.guild.id)];
 		await context.channel.send(
-			await this.client.bulbutils.translate("action_success_temp", context.guild?.id, {
-				action: await this.client.bulbutils.translate("mod_action_types.temp_ban", context.guild?.id, {}),
+			await this.client.bulbutils.translate("action_success_temp", context.guild.id, {
+				action: await this.client.bulbutils.translate("mod_action_types.temp_ban", context.guild.id, {}),
 				target: target.user,
 				reason,
 				infraction_id: infID,
@@ -91,17 +91,17 @@ export default class extends Command {
 
 		const client: BulbBotClient = this.client;
 		setTimeout(async function () {
-			if ((await infractionsManager.isActive(<Snowflake>context.guild?.id, infID!)) === false) return;
-			await infractionsManager.setActive(<Snowflake>context.guild?.id, infID!, false);
+			if (!context.guild?.id || !context.guild.me || (await infractionsManager.isActive(context.guild.id, infID)) === false) return;
+			await infractionsManager.setActive(context.guild.id, infID, false);
 
 			infID = await infractionsManager.unban(
 				client,
-				<Guild>context.guild,
+				context.guild,
 				BanType.TEMP,
 				target.user,
-				<GuildMember>context.guild?.me,
-				await client.bulbutils.translate("global_mod_action_log", context.guild?.id, {
-					action: await client.bulbutils.translate("mod_action_types.auto_unban", context.guild?.id, {}),
+				context.guild.me,
+				await client.bulbutils.translate("global_mod_action_log", context.guild.id, {
+					action: await client.bulbutils.translate("mod_action_types.auto_unban", context.guild.id, {}),
 					moderator: client.user,
 					target: target.user,
 					reason: "Automatic unban",

--- a/src/commands/Moderation/unban.ts
+++ b/src/commands/Moderation/unban.ts
@@ -1,6 +1,6 @@
 import Command from "../../structures/Command";
 import CommandContext from "../../structures/CommandContext";
-import { Guild, GuildMember, Message, Snowflake, User } from "discord.js";
+import { Message, Snowflake, User } from "discord.js";
 import { NonDigits } from "../../utils/Regex";
 import InfractionsManager from "../../utils/managers/InfractionsManager";
 import BulbBotClient from "../../structures/BulbBotClient";
@@ -31,7 +31,7 @@ export default class extends Command {
 		const target: User | undefined = await this.client.bulbfetch.getUser(targetID);
 		let reason: string = args.slice(1).join(" ");
 
-		if (!target)
+		if (!target || !context.guild || !context.member)
 			return await context.channel.send(
 				await this.client.bulbutils.translate("global_not_found", context.guild?.id, {
 					type: await this.client.bulbutils.translate("global_not_found_types.user", context.guild?.id, {}),
@@ -50,10 +50,10 @@ export default class extends Command {
 
 		const infID = await infractionsManager.unban(
 			this.client,
-			<Guild>context.guild,
+			context.guild,
 			BanType.MANUAL,
 			target,
-			<GuildMember>context.member,
+			context.member,
 			await this.client.bulbutils.translate("global_mod_action_log", context.guild?.id, {
 				action: await this.client.bulbutils.translate("mod_action_types.unban", context.guild?.id, {}),
 				moderator: context.author,

--- a/src/commands/Moderation/unban.ts
+++ b/src/commands/Moderation/unban.ts
@@ -41,12 +41,12 @@ export default class extends Command {
 				}),
 			);
 
-		const banList = await context.guild?.bans.fetch();
-		const bannedUser = banList?.find((user) => user.user.id === targetID);
+		const banList = await context.guild.bans.fetch();
+		const bannedUser = banList.find((user) => user.user.id === targetID);
 
-		if (!bannedUser) return context.channel.send(await this.client.bulbutils.translate("not_banned", context.guild?.id, { target }));
+		if (!bannedUser) return context.channel.send(await this.client.bulbutils.translate("not_banned", context.guild.id, { target }));
 
-		if (!reason) reason = await this.client.bulbutils.translate("global_no_reason", context.guild?.id, {});
+		if (!reason) reason = await this.client.bulbutils.translate("global_no_reason", context.guild.id, {});
 
 		const infID = await infractionsManager.unban(
 			this.client,
@@ -54,8 +54,8 @@ export default class extends Command {
 			BanType.MANUAL,
 			target,
 			context.member,
-			await this.client.bulbutils.translate("global_mod_action_log", context.guild?.id, {
-				action: await this.client.bulbutils.translate("mod_action_types.unban", context.guild?.id, {}),
+			await this.client.bulbutils.translate("global_mod_action_log", context.guild.id, {
+				action: await this.client.bulbutils.translate("mod_action_types.unban", context.guild.id, {}),
 				moderator: context.author,
 				target,
 				reason,
@@ -64,8 +64,8 @@ export default class extends Command {
 		);
 
 		await context.channel.send(
-			await this.client.bulbutils.translate("action_success", context.guild?.id, {
-				action: await this.client.bulbutils.translate("mod_action_types.unban", context.guild?.id, {}),
+			await this.client.bulbutils.translate("action_success", context.guild.id, {
+				action: await this.client.bulbutils.translate("mod_action_types.unban", context.guild.id, {}),
 				target,
 				reason,
 				infraction_id: infID,

--- a/src/commands/Moderation/undeafen.ts
+++ b/src/commands/Moderation/undeafen.ts
@@ -39,16 +39,16 @@ export default class extends Command {
 					usage: this.usage,
 				}),
 			);
-		if (!target.voice.channel) return context.channel.send(await this.client.bulbutils.translate("global_not_in_voice", context.guild?.id, { target: target.user }));
-		if (!target.voice.serverDeaf) return context.channel.send(await this.client.bulbutils.translate("undeafen_not_deaf", context.guild?.id, { target: target.user }));
+		if (!target.voice.channel) return context.channel.send(await this.client.bulbutils.translate("global_not_in_voice", context.guild.id, { target: target.user }));
+		if (!target.voice.serverDeaf) return context.channel.send(await this.client.bulbutils.translate("undeafen_not_deaf", context.guild.id, { target: target.user }));
 
 		const infID = await infractionsManager.undeafen(
 			this.client,
 			context.guild,
 			target,
 			context.member,
-			await this.client.bulbutils.translate("global_mod_action_log", context.guild?.id, {
-				action: await this.client.bulbutils.translate("mod_action_types.undeafen", context.guild?.id, {}),
+			await this.client.bulbutils.translate("global_mod_action_log", context.guild.id, {
+				action: await this.client.bulbutils.translate("mod_action_types.undeafen", context.guild.id, {}),
 				moderator: context.author,
 				target: target.user,
 				reason,
@@ -57,8 +57,8 @@ export default class extends Command {
 		);
 
 		return context.channel.send(
-			await this.client.bulbutils.translate("action_success", context.guild?.id, {
-				action: await this.client.bulbutils.translate("mod_action_types.undeafen", context.guild?.id, {}),
+			await this.client.bulbutils.translate("action_success", context.guild.id, {
+				action: await this.client.bulbutils.translate("mod_action_types.undeafen", context.guild.id, {}),
 				target: target.user,
 				reason,
 				infraction_id: infID,

--- a/src/commands/Moderation/undeafen.ts
+++ b/src/commands/Moderation/undeafen.ts
@@ -1,6 +1,6 @@
 import Command from "../../structures/Command";
 import CommandContext from "../../structures/CommandContext";
-import { Guild, GuildMember, Message, Snowflake } from "discord.js";
+import { GuildMember, Message, Snowflake } from "discord.js";
 import { NonDigits } from "../../utils/Regex";
 import InfractionsManager from "../../utils/managers/InfractionsManager";
 import BulbBotClient from "../../structures/BulbBotClient";
@@ -30,7 +30,7 @@ export default class extends Command {
 		let reason: string = args.slice(1).join(" ");
 
 		if (!reason) reason = await this.client.bulbutils.translate("global_no_reason", context.guild?.id, {});
-		if (!target)
+		if (!target || !context.guild || !context.member)
 			return context.channel.send(
 				await this.client.bulbutils.translate("global_not_found", context.guild?.id, {
 					type: await this.client.bulbutils.translate("global_not_found_types.member", context.guild?.id, {}),
@@ -44,9 +44,9 @@ export default class extends Command {
 
 		const infID = await infractionsManager.undeafen(
 			this.client,
-			<Guild>context.guild,
+			context.guild,
 			target,
-			<GuildMember>context.member,
+			context.member,
 			await this.client.bulbutils.translate("global_mod_action_log", context.guild?.id, {
 				action: await this.client.bulbutils.translate("mod_action_types.undeafen", context.guild?.id, {}),
 				moderator: context.author,

--- a/src/commands/Moderation/unmute.ts
+++ b/src/commands/Moderation/unmute.ts
@@ -1,6 +1,6 @@
 import Command from "../../structures/Command";
 import CommandContext from "../../structures/CommandContext";
-import { Guild, GuildMember, Message, Snowflake } from "discord.js";
+import { GuildMember, Message, Snowflake } from "discord.js";
 import { NonDigits } from "../../utils/Regex";
 import InfractionsManager from "../../utils/managers/InfractionsManager";
 import { MuteType } from "../../utils/types/MuteType";
@@ -41,12 +41,12 @@ export default class extends Command {
 				}),
 			);
 
-		if (await this.client.bulbutils.resolveUserHandle(context, this.client.bulbutils.checkUser(context, target), target.user)) return;
+		if (!context.guild || (await this.client.bulbutils.resolveUserHandle(context, this.client.bulbutils.checkUser(context, target), target.user))) return;
 		if (target.communicationDisabledUntilTimestamp === null) return context.channel.send(await this.client.bulbutils.translate("mute_not_muted", context.guild?.id, { target: target.user }));
 
 		const infID = await infractionsManager.unmute(
 			this.client,
-			<Guild>context.guild,
+			context.guild,
 			MuteType.MANUAL,
 			target,
 			context.author,

--- a/src/commands/Moderation/unmute.ts
+++ b/src/commands/Moderation/unmute.ts
@@ -42,7 +42,7 @@ export default class extends Command {
 			);
 
 		if (!context.guild || (await this.client.bulbutils.resolveUserHandle(context, this.client.bulbutils.checkUser(context, target), target.user))) return;
-		if (target.communicationDisabledUntilTimestamp === null) return context.channel.send(await this.client.bulbutils.translate("mute_not_muted", context.guild?.id, { target: target.user }));
+		if (target.communicationDisabledUntilTimestamp === null) return context.channel.send(await this.client.bulbutils.translate("mute_not_muted", context.guild.id, { target: target.user }));
 
 		const infID = await infractionsManager.unmute(
 			this.client,
@@ -50,8 +50,8 @@ export default class extends Command {
 			MuteType.MANUAL,
 			target,
 			context.author,
-			await this.client.bulbutils.translate("global_mod_action_log", context.guild?.id, {
-				action: await this.client.bulbutils.translate("mod_action_types.unmute", context.guild?.id, {}),
+			await this.client.bulbutils.translate("global_mod_action_log", context.guild.id, {
+				action: await this.client.bulbutils.translate("mod_action_types.unmute", context.guild.id, {}),
 				moderator: context.author,
 				target: target.user,
 				reason: reason,
@@ -60,8 +60,8 @@ export default class extends Command {
 		);
 
 		await context.channel.send(
-			await this.client.bulbutils.translate("action_success", context.guild?.id, {
-				action: await this.client.bulbutils.translate("mod_action_types.unmute", context.guild?.id, {}),
+			await this.client.bulbutils.translate("action_success", context.guild.id, {
+				action: await this.client.bulbutils.translate("mod_action_types.unmute", context.guild.id, {}),
 				target: target.user,
 				reason,
 				infraction_id: infID,

--- a/src/commands/Moderation/warn.ts
+++ b/src/commands/Moderation/warn.ts
@@ -42,17 +42,18 @@ export default class extends Command {
 			return;
 		}
 		if (!reason) reason = await this.client.bulbutils.translate("global_no_reason", context.guild?.id, {});
+		if (!context.guild || !context.member) return;
 
 		if (await this.client.bulbutils.resolveUserHandle(context, this.client.bulbutils.checkUser(context, target), target.user)) return;
 
 		//Executes the action
 		const infID = await infractionsManager.warn(
 			this.client,
-			<string>context.guild?.id,
+			context.guild.id,
 			target.user,
-			<GuildMember>context.member,
-			await this.client.bulbutils.translate("global_mod_action_log", context.guild?.id, {
-				action: await this.client.bulbutils.translate("mod_action_types.warn", context.guild?.id, {}),
+			context.member,
+			await this.client.bulbutils.translate("global_mod_action_log", context.guild.id, {
+				action: await this.client.bulbutils.translate("mod_action_types.warn", context.guild.id, {}),
 				moderator: context.author,
 				target: target.user,
 				reason,
@@ -62,8 +63,8 @@ export default class extends Command {
 
 		//Sends the respond context
 		await context.channel.send(
-			await this.client.bulbutils.translate("action_success", context.guild?.id, {
-				action: await this.client.bulbutils.translate("mod_action_types.warn", context.guild?.id, {}),
+			await this.client.bulbutils.translate("action_success", context.guild.id, {
+				action: await this.client.bulbutils.translate("mod_action_types.warn", context.guild.id, {}),
 				target: target.user,
 				reason,
 				infraction_id: infID,

--- a/src/events/bot/interactionCreate.ts
+++ b/src/events/bot/interactionCreate.ts
@@ -80,13 +80,14 @@ export default class extends Event {
 			if (!command) return;
 			const invalidReason = await command.validate(context, args);
 			if (invalidReason !== undefined) {
+				// CommandContext#reply is safe here - deferReply has not yet been called
 				if (invalidReason) await context.reply({ content: invalidReason, ephemeral: true });
 				return;
 			}
 
 			let used = `/${command.qualifiedName}`;
 			args.forEach((arg) => (used += ` ${arg}`));
-			await loggingManager.sendCommandLog(this.client, interaction.guild!, context.author, context.channel.id, used);
+			await loggingManager.sendCommandLog(this.client, interaction.guild, context.author, context.channel.id, used);
 
 			await context.deferReply();
 			await command.run(context, args);

--- a/src/events/bot/interactionCreate.ts
+++ b/src/events/bot/interactionCreate.ts
@@ -48,14 +48,14 @@ export default class extends Event {
 				return void (await context.reply({ content: await this.client.bulbutils.translate("global_missing_permissions", interaction.guild?.id, {}), ephemeral: true }));
 
 			const channel = this.client.guilds.cache.get(context.guild.id)?.channels.cache.get(context.channelId);
-			const message = channel?.isText() && (await channel.messages?.fetch(interaction.targetId));
+			const message = channel?.isText() && (await channel.messages.fetch(interaction.targetId));
 
 			if (
 				!message ||
 				!interaction.guild ||
 				(await this.client.bulbutils.resolveUserHandleFromInteraction(
 					interaction,
-					await this.client.bulbutils.checkUserFromInteraction(interaction, await interaction.guild?.members.fetch(message.author.id)),
+					await this.client.bulbutils.checkUserFromInteraction(interaction, await interaction.guild.members.fetch(message.author.id)),
 					message.author,
 				))
 			)

--- a/src/events/bot/ready.ts
+++ b/src/events/bot/ready.ts
@@ -27,7 +27,7 @@ export default class extends Event {
 
 		registerSlashCommands(this.client);
 
-		this.client.log.client(`[CLIENT] ${this.client.user!.username} successfully logged and ready`);
+		this.client.log.client(`[CLIENT] ${this.client.user?.username || "Bot (client.user is undefined?)"} successfully logged and ready`);
 		this.client.log.client(`[CLIENT] Listening to ${this.client.events.size} event(s)`);
 		this.client.log.client(`[CLIENT] Listening to ${this.client.commands.size} command(s)`);
 	}

--- a/src/events/guild/channels/inviteCreate.ts
+++ b/src/events/guild/channels/inviteCreate.ts
@@ -36,6 +36,7 @@ export default class extends Event {
 			max_uses: invite.maxUses === 0 ? "unlimited" : invite.maxUses,
 		});
 
-		await loggingManager.sendEventLog(this.client, <Guild>invite.guild, "invite", log);
+		// The difference between Guild and InviteGuild doesn't matter here. TODO: maybe widen the parameter type
+		await loggingManager.sendEventLog(this.client, invite.guild as Guild, "invite", log);
 	}
 }

--- a/src/events/guild/channels/inviteCreate.ts
+++ b/src/events/guild/channels/inviteCreate.ts
@@ -16,7 +16,11 @@ export default class extends Event {
 		if (!inv.guild) return;
 
 		const invite = {
-			maxAge: inv.maxAge,
+			// This is a safe coercian to a number. `null` will be 0 if present
+			// This only works if you know it will be an integer, however it can be safer
+			// than using `+` for coercian, as `+undefined` results in `NaN`
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			maxAge: ~~inv.maxAge!,
 			maxUses: inv.maxUses,
 			guild: inv.guild,
 			code: inv.code,
@@ -28,7 +32,7 @@ export default class extends Event {
 
 		const log: string = await this.client.bulbutils.translate("event_invite_create", invite.guild.id, {
 			invite,
-			expire_time: invite.maxAge === 0 ? "never" : `<t:${Math.round(Date.now() / 1000) + invite.maxAge!}:R>`,
+			expire_time: invite.maxAge === 0 ? "never" : `<t:${Math.round(Date.now() / 1000) + invite.maxAge}:R>`,
 			max_uses: invite.maxUses === 0 ? "unlimited" : invite.maxUses,
 		});
 

--- a/src/events/guild/channels/inviteCreate.ts
+++ b/src/events/guild/channels/inviteCreate.ts
@@ -25,8 +25,8 @@ export default class extends Event {
 			guild: inv.guild,
 			code: inv.code,
 			inviter: {
-				tag: inv.inviter !== null ? inv.inviter?.tag : "Server Widget",
-				id: inv.inviter !== null ? inv.inviter?.id : "N/A",
+				tag: inv.inviter !== null ? inv.inviter.tag : "Server Widget",
+				id: inv.inviter !== null ? inv.inviter.id : "N/A",
 			},
 		};
 

--- a/src/events/guild/channels/inviteDelete.ts
+++ b/src/events/guild/channels/inviteDelete.ts
@@ -15,7 +15,7 @@ export default class extends Event {
 	public async run(invite: Invite): Promise<void> {
 		// @ts-expect-error
 		const guild: Guild = invite.guild;
-		if (!guild?.me?.permissions.has(Permissions.FLAGS.VIEW_AUDIT_LOG)) return;
+		if (!guild.me?.permissions.has(Permissions.FLAGS.VIEW_AUDIT_LOG)) return;
 
 		const logs: GuildAuditLogs<"INVITE_DELETE"> = await guild.fetchAuditLogs({ limit: 1, type: "INVITE_DELETE" });
 		const first = logs.entries.first();

--- a/src/events/guild/guildBanAdd.ts
+++ b/src/events/guild/guildBanAdd.ts
@@ -25,12 +25,12 @@ export default class extends Event {
 		const { executor, target: logTarget } = banLog;
 		let { reason } = banLog;
 
-		if (executor!.id === this.client.user!.id) return;
+		if (!executor?.id || executor.id === this.client.user?.id) return;
 		if (ban.user.id !== logTarget?.id) return;
 		if (reason === null) reason = await this.client.bulbutils.translate("global_no_reason", ban.guild.id, {});
 
-		await infractionsManager.createInfraction(ban.guild.id, "Manual Ban", true, reason, ban.user, executor!);
-		const infID: number = await infractionsManager.getLatestInfraction(ban.guild.id, executor!.id, ban.user.id, "Manual Ban");
-		await loggingManager.sendModAction(this.client, ban.guild.id, "manually banned", ban.user, executor!, reason, infID);
+		await infractionsManager.createInfraction(ban.guild.id, "Manual Ban", true, reason, ban.user, executor);
+		const infID: number = await infractionsManager.getLatestInfraction(ban.guild.id, executor.id, ban.user.id, "Manual Ban");
+		await loggingManager.sendModAction(this.client, ban.guild.id, "manually banned", ban.user, executor, reason, infID);
 	}
 }

--- a/src/events/guild/guildBanRemove.ts
+++ b/src/events/guild/guildBanRemove.ts
@@ -24,12 +24,12 @@ export default class extends Event {
 
 		const { executor, target: logTarget } = banLog;
 		let { reason } = banLog;
-		if (executor!.id === this.client.user!.id) return;
+		if (!executor?.id || executor.id === this.client.user?.id) return;
 		if (ban.user.id !== logTarget?.id) return;
 		if (reason === null) reason = await this.client.bulbutils.translate("global_no_reason", ban.guild.id, {});
 
-		await infractionsManager.createInfraction(ban.guild.id, "Manual Unban", true, reason, ban.user, executor!);
-		const infID: number = await infractionsManager.getLatestInfraction(ban.guild.id, executor!.id, ban.user.id, "Manual Unban");
-		await loggingManager.sendModAction(this.client, ban.guild.id, "manually unbanned", ban.user, executor!, reason, infID);
+		await infractionsManager.createInfraction(ban.guild.id, "Manual Unban", true, reason, ban.user, executor);
+		const infID: number = await infractionsManager.getLatestInfraction(ban.guild.id, executor.id, ban.user.id, "Manual Unban");
+		await loggingManager.sendModAction(this.client, ban.guild.id, "manually unbanned", ban.user, executor, reason, infID);
 	}
 }

--- a/src/events/guild/guildCreate.ts
+++ b/src/events/guild/guildCreate.ts
@@ -1,5 +1,5 @@
 import Event from "../../structures/Event";
-import { Guild, TextChannel } from "discord.js";
+import { Guild } from "discord.js";
 import DatabaseManager from "../../utils/managers/DatabaseManager";
 import { invite } from "../../Config";
 import * as Emotes from "../../emotes.json";
@@ -18,8 +18,8 @@ export default class extends Event {
 		this.client.log.info(`[GUILD] Joined a new guild ${guild.name} (${guild.id})`);
 
 		await databaseManager.createGuild(guild);
-		(<TextChannel | undefined>this.client.channels.cache.get(invite))?.send(
-			`${Emotes.other.JOIN} Joined new guild: **${guild.name}** \`(${guild.id})\` owned by <@${guild.ownerId}> \`(${guild.ownerId})\`\nMembers: **${guild.memberCount}**`,
-		);
+		const channel = this.client.channels.cache.get(invite);
+		channel?.isText() &&
+			channel.send(`${Emotes.other.JOIN} Joined new guild: **${guild.name}** \`(${guild.id})\` owned by <@${guild.ownerId}> \`(${guild.ownerId})\`\nMembers: **${guild.memberCount}**`);
 	}
 }

--- a/src/events/guild/guildDelete.ts
+++ b/src/events/guild/guildDelete.ts
@@ -1,5 +1,5 @@
 import Event from "../../structures/Event";
-import { Guild, TextChannel } from "discord.js";
+import { Guild } from "discord.js";
 import DatabaseManager from "../../utils/managers/DatabaseManager";
 import { invite } from "../../Config";
 import * as Emotes from "../../emotes.json";
@@ -18,8 +18,7 @@ export default class extends Event {
 		this.client.log.info(`[GUILD] Left a guild ${guild.name} (${guild.id})`);
 
 		await databaseManager.deleteGuild(guild.id);
-		(<TextChannel | undefined>this.client.channels.cache.get(invite))?.send(
-			`${Emotes.other.LEAVE} Left guild: **${guild.name}** \`(${guild.id})\` owned by <@${guild.ownerId}> \`(${guild.ownerId})\`\nMembers: **${guild.memberCount}**`,
-		);
+		const channel = this.client.channels.cache.get(invite);
+		channel?.isText() && channel.send(`${Emotes.other.LEAVE} Left guild: **${guild.name}** \`(${guild.id})\` owned by <@${guild.ownerId}> \`(${guild.ownerId})\`\nMembers: **${guild.memberCount}**`);
 	}
 }

--- a/src/events/guild/member/guildMemberAdd.ts
+++ b/src/events/guild/member/guildMemberAdd.ts
@@ -33,7 +33,8 @@ export default class extends Event {
 			const buffer = await axios.get(member?.displayAvatarURL(), {
 				responseType: "arraybuffer",
 			});
-			const avatarHash = await imageHash.hash(buffer.data, 8);
+			// Type inferred manually from the source code
+			const avatarHash = await (imageHash.hash(buffer.data, 8) as Promise<string>);
 			if (automod.avatarHashes.includes(avatarHash)) {
 				const automodManager: AutoModManager = new AutoModManager();
 

--- a/src/events/guild/member/guildMemberAdd.ts
+++ b/src/events/guild/member/guildMemberAdd.ts
@@ -30,7 +30,7 @@ export default class extends Event {
 
 		const automod: AutoModConfiguration = await databaseManager.getAutoModConfig(member.guild.id);
 		if (automod.enabled && automod.avatarHashes.length > 0 && automod.punishmentAvatarBans) {
-			const buffer = await axios.get(member?.displayAvatarURL(), {
+			const buffer = await axios.get(member.displayAvatarURL(), {
 				responseType: "arraybuffer",
 			});
 			// Type inferred manually from the source code

--- a/src/events/guild/member/guildMemberRemove.ts
+++ b/src/events/guild/member/guildMemberRemove.ts
@@ -56,11 +56,11 @@ export default class extends Event {
 		if (createdTimestamp + 3000 < Date.now()) return;
 		if (target?.id !== member.user.id) return;
 
-		if (executor!.id === this.client.user!.id) return;
+		if (!executor?.id || executor.id === this.client.user?.id) return;
 		if (reason === null) reason = await this.client.bulbutils.translate("global_no_reason", member.guild.id, {});
 
-		await infractionsManager.createInfraction(member.guild.id, "Manual Kick", true, reason, member.user, executor!);
-		const infID: number = await infractionsManager.getLatestInfraction(member.guild.id, executor!.id, target.id, "Manual Kick");
-		await loggingManager.sendModAction(this.client, member.guild.id, "manually kicked", member.user, executor!, reason, infID);
+		await infractionsManager.createInfraction(member.guild.id, "Manual Kick", true, reason, member.user, executor);
+		const infID: number = await infractionsManager.getLatestInfraction(member.guild.id, executor.id, target.id, "Manual Kick");
+		await loggingManager.sendModAction(this.client, member.guild.id, "manually kicked", member.user, executor, reason, infID);
 	}
 }

--- a/src/events/guild/member/guildMemberUpdate.ts
+++ b/src/events/guild/member/guildMemberUpdate.ts
@@ -36,7 +36,7 @@ export default class extends Event {
 			// If newMember is muted check if the executor is bot. If not, log as manual mute
 			// If newMember is not muted check if the executor is bot. If not, log as manual unmute, else log as auto mute
 			if (newMember.communicationDisabledUntilTimestamp === null && executor) {
-				if (executor?.id !== this.client.user?.id) {
+				if (executor.id !== this.client.user?.id) {
 					await infractionsManager.createInfraction(
 						newMember.guild.id,
 						"Unmute",
@@ -48,7 +48,7 @@ export default class extends Event {
 					const infID: number = await infractionsManager.getLatestInfraction(newMember.guild.id, executor.id, newMember.user.id, "Unmute");
 					await loggingManager.sendModAction(
 						this.client,
-						newMember.guild?.id,
+						newMember.guild.id,
 						await this.client.bulbutils.translate("mod_action_types.unmute", newMember.guild.id, {}),
 						newMember.user,
 						executor,
@@ -57,7 +57,7 @@ export default class extends Event {
 					);
 				}
 			} else {
-				if (!executor?.id || executor?.id === this.client.user?.id || newMember.communicationDisabledUntilTimestamp === null) return;
+				if (!executor?.id || executor.id === this.client.user?.id || newMember.communicationDisabledUntilTimestamp === null) return;
 
 				await infractionsManager.createInfraction(
 					newMember.guild.id,

--- a/src/events/guild/member/guildMemberUpdate.ts
+++ b/src/events/guild/member/guildMemberUpdate.ts
@@ -57,24 +57,24 @@ export default class extends Event {
 					);
 				}
 			} else {
-				if (executor?.id === this.client.user?.id) return;
+				if (!executor?.id || executor?.id === this.client.user?.id) return;
 
 				await infractionsManager.createInfraction(
 					newMember.guild.id,
 					"Mute",
-					<number>newMember.communicationDisabledUntilTimestamp!,
+					newMember.communicationDisabledUntilTimestamp,
 					auditLog?.reason ? <string>auditLog?.reason : await this.client.bulbutils.translate("global_no_reason", newMember.guild.id, {}),
 					newMember.user,
-					<User>executor,
+					executor,
 				);
-				const infID: number = await infractionsManager.getLatestInfraction(newMember.guild.id, <Snowflake>executor?.id, newMember.user.id, "Mute");
+				const infID: number = await infractionsManager.getLatestInfraction(newMember.guild.id, executor.id, newMember.user.id, "Mute");
 				await loggingManager.sendModActionTemp(
 					this.client,
 					newMember.guild,
 					await this.client.bulbutils.translate("mod_action_types.mute", newMember.guild.id, {}),
 					newMember.user,
-					<User>executor,
-					auditLog?.reason ? <string>auditLog?.reason : await this.client.bulbutils.translate("global_no_reason", newMember.guild.id, {}),
+					executor,
+					auditLog?.reason ? auditLog.reason : await this.client.bulbutils.translate("global_no_reason", newMember.guild.id, {}),
 					infID,
 					newMember.communicationDisabledUntilTimestamp,
 				);
@@ -107,20 +107,20 @@ export default class extends Event {
 		switch (change) {
 			case "nickname":
 				part = "member";
-				if (auditLog?.changes && auditLog!.changes[0].key === "nick") {
+				if (auditLog?.changes && auditLog.changes[0].key === "nick") {
 					executor = auditLog.executor;
-					if (executor?.id === this.client.user!.id) return;
+					if (!executor?.id || executor.id === this.client.user?.id) return;
 
 					const reason = auditLog.reason ?? (await this.client.bulbutils.translate("global_no_reason", newMember.guild.id, {}));
-					if (!executor?.bot && executor?.id !== newMember.user.id) await infractionsManager.createInfraction(newMember.guild.id, "Manual Nickname", true, reason, newMember.user, executor!);
+					if (!executor.bot && executor.id !== newMember.user.id) await infractionsManager.createInfraction(newMember.guild.id, "Manual Nickname", true, reason, newMember.user, executor);
 					const infID: number =
-						!executor?.bot && executor?.id !== newMember.user.id ? await infractionsManager.getLatestInfraction(newMember.guild.id, executor!.id, newMember.user.id, "Manual Nickname") : -1;
+						!executor.bot && executor.id !== newMember.user.id ? await infractionsManager.getLatestInfraction(newMember.guild.id, executor.id, newMember.user.id, "Manual Nickname") : -1;
 					const translateKey =
 						executor === null || executor.id === newMember.id
 							? newMember.nickname
 								? "event_member_update_nickname"
 								: "event_member_remove_nickname"
-							: executor?.bot
+							: executor.bot
 							? newMember.nickname
 								? "event_member_update_nickname_moderator"
 								: "event_member_remove_nickname_moderator"
@@ -173,6 +173,6 @@ export default class extends Event {
 				break;
 		}
 
-		await loggingManager.sendEventLog(this.client, newMember.guild, part!, message);
+		await loggingManager.sendEventLog(this.client, newMember.guild, part, message);
 	}
 }

--- a/src/events/guild/roles/roleUpdate.ts
+++ b/src/events/guild/roles/roleUpdate.ts
@@ -19,7 +19,7 @@ export default class extends Event {
 
 	public async run(oldRole: Role, newRole: Role): Promise<void> {
 		const config: GuildConfiguration = await databaseManager.getConfig(newRole.guild.id);
-		if (newRole.rawPosition > newRole.guild.me!.roles.highest.rawPosition) {
+		if (newRole.rawPosition > newRole.guild.me?.roles.highest.rawPosition) {
 			if (newRole.id === config.muteRole) await databaseManager.setMuteRole(newRole.guild.id, null);
 			else if (newRole.id === config.autorole) await databaseManager.setAutoRole(newRole.guild.id, null);
 		}

--- a/src/events/guild/scheduledEvents/guildScheduledEventCreate.ts
+++ b/src/events/guild/scheduledEvents/guildScheduledEventCreate.ts
@@ -14,7 +14,7 @@ export default class extends Event {
 		if (!scheduledEvent.guild?.me?.permissions.has(Permissions.FLAGS.VIEW_AUDIT_LOG)) return;
 
 		let msg = "";
-		const logs: GuildAuditLogs<"GUILD_SCHEDULED_EVENT_CREATE"> = await scheduledEvent.guild?.fetchAuditLogs({ limit: 1, type: "GUILD_SCHEDULED_EVENT_CREATE" });
+		const logs: GuildAuditLogs<"GUILD_SCHEDULED_EVENT_CREATE"> = await scheduledEvent.guild.fetchAuditLogs({ limit: 1, type: "GUILD_SCHEDULED_EVENT_CREATE" });
 		const first = logs.entries.first();
 		if (!first) return;
 
@@ -32,7 +32,7 @@ export default class extends Event {
 					: doesIncludeDescription
 					? "event_guild_scheduled_event_create_moderator_description"
 					: "event_guild_scheduled_event_create_moderator_none",
-				scheduledEvent.guild?.id,
+				scheduledEvent.guild.id,
 				{ scheduledEvent, moderator: executor },
 			);
 		}
@@ -46,11 +46,11 @@ export default class extends Event {
 					: doesIncludeDescription
 					? "event_guild_scheduled_event_create_description"
 					: "event_guild_scheduled_event_create_none",
-				scheduledEvent.guild?.id,
+				scheduledEvent.guild.id,
 				{ scheduledEvent },
 			);
 		}
 
-		await loggingManager.sendEventLog(this.client, scheduledEvent.guild!, "other", msg);
+		await loggingManager.sendEventLog(this.client, scheduledEvent.guild, "other", msg);
 	}
 }

--- a/src/events/guild/scheduledEvents/guildScheduledEventDelete.ts
+++ b/src/events/guild/scheduledEvents/guildScheduledEventDelete.ts
@@ -14,23 +14,23 @@ export default class extends Event {
 		if (!scheduledEvent.guild?.me?.permissions.has(Permissions.FLAGS.VIEW_AUDIT_LOG)) return;
 
 		let msg = "";
-		const logs: GuildAuditLogs<"GUILD_SCHEDULED_EVENT_DELETE"> = await scheduledEvent.guild?.fetchAuditLogs({ limit: 1, type: "GUILD_SCHEDULED_EVENT_DELETE" });
+		const logs: GuildAuditLogs<"GUILD_SCHEDULED_EVENT_DELETE"> = await scheduledEvent.guild.fetchAuditLogs({ limit: 1, type: "GUILD_SCHEDULED_EVENT_DELETE" });
 		const first = logs.entries.first();
 		if (!first) return;
 
 		const { executor, createdTimestamp } = first;
 		if (Date.now() < createdTimestamp + 3000) {
-			msg = await this.client.bulbutils.translate("event_guild_scheduled_event_delete_moderator", scheduledEvent.guild?.id, {
+			msg = await this.client.bulbutils.translate("event_guild_scheduled_event_delete_moderator", scheduledEvent.guild.id, {
 				scheduledEvent,
 				moderator: executor,
 			});
 		}
 
 		if (!msg)
-			msg = await this.client.bulbutils.translate("event_guild_scheduled_event_delete", scheduledEvent.guild?.id, {
+			msg = await this.client.bulbutils.translate("event_guild_scheduled_event_delete", scheduledEvent.guild.id, {
 				scheduledEvent,
 			});
 
-		await loggingManager.sendEventLog(this.client, scheduledEvent.guild!, "other", msg);
+		await loggingManager.sendEventLog(this.client, scheduledEvent.guild, "other", msg);
 	}
 }

--- a/src/events/guild/scheduledEvents/guildScheduledEventUpdate.ts
+++ b/src/events/guild/scheduledEvents/guildScheduledEventUpdate.ts
@@ -15,7 +15,7 @@ export default class extends Event {
 	async run(newScheduledEvent: GuildScheduledEvent) {
 		if (!newScheduledEvent.guild?.me?.permissions.has(Permissions.FLAGS.VIEW_AUDIT_LOG)) return;
 
-		const logs: GuildAuditLogs<"GUILD_SCHEDULED_EVENT_CREATE"> = await newScheduledEvent.guild?.fetchAuditLogs({ limit: 1, type: "GUILD_SCHEDULED_EVENT_CREATE" });
+		const logs: GuildAuditLogs<"GUILD_SCHEDULED_EVENT_CREATE"> = await newScheduledEvent.guild.fetchAuditLogs({ limit: 1, type: "GUILD_SCHEDULED_EVENT_CREATE" });
 		const first = logs.entries.first();
 		if (!first) return;
 
@@ -27,7 +27,7 @@ export default class extends Event {
 
 		for (const change of changes) {
 			log.push(
-				await this.client.bulbutils.translate("event_change", newScheduledEvent.guild?.id, {
+				await this.client.bulbutils.translate("event_change", newScheduledEvent.guild.id, {
 					part: change.key,
 					before: change.old ? change.old : "none",
 					after: change.new ? change.new : "none",
@@ -37,9 +37,9 @@ export default class extends Event {
 
 		await loggingManager.sendEventLog(
 			this.client,
-			newScheduledEvent.guild!,
+			newScheduledEvent.guild,
 			"other",
-			await this.client.bulbutils.translate("event_update_scheduled_event", newScheduledEvent.guild?.id, {
+			await this.client.bulbutils.translate("event_update_scheduled_event", newScheduledEvent.guild.id, {
 				moderator: executor,
 				event: newScheduledEvent,
 				changes: log.join("\n> "),

--- a/src/events/message/messageCreate.ts
+++ b/src/events/message/messageCreate.ts
@@ -29,14 +29,14 @@ export default class extends Event {
 
 		// checks if the user is in the blacklist
 		if (this.client.blacklist.get(context.author.id) !== undefined) return;
-		if (!context.guild || context.author.bot) return;
+		if (!context.guild || context.author.bot || !this.client.user?.id) return;
 
 		// checks if the guild is in the blacklist
 		if (this.client.blacklist.get(context.guild.id)) return;
 
 		await databaseManager.addToMessageToDB(message);
 
-		const mentionRegex = RegExp(`^<@!?${this.client.user!.id}>`);
+		const mentionRegex = RegExp(`^<@!?${this.client.user.id}>`);
 		let guildCfg = await databaseManager.getConfig(context.guild.id);
 
 		if ((guildCfg === undefined || guildCfg.prefix === undefined) && (context.content.startsWith(Config.prefix) || mentionRegex.test(context.content))) {
@@ -123,7 +123,7 @@ export default class extends Event {
 	private async resolveCommand(options: ResolveCommandOptions): Promise<Command | Message | undefined> {
 		const { context, baseCommand, args } = options;
 		const command = baseCommand;
-		if (!context.guild?.me) await this.client.bulbfetch.getGuildMember(context.guild?.members, this.client.user!.id);
+		if (!context.guild?.me) await this.client.bulbfetch.getGuildMember(context.guild?.members, this.client.user?.id);
 		if (!context.guild?.me) return; // Shouldn't be possible to return here. Narrows the type
 		const invalidReason = await command.validate(context, args, options);
 		if (invalidReason !== undefined) {

--- a/src/events/message/messageDelete.ts
+++ b/src/events/message/messageDelete.ts
@@ -83,7 +83,7 @@ export default class extends Event {
 			});
 
 		if (msg.length >= 1850) {
-			fs.writeFileSync(`${__dirname}/../../../files/MESSAGE_DELETE-${guild?.id}.txt`, content);
+			fs.writeFileSync(`${__dirname}/../../../files/MESSAGE_DELETE-${guild.id}.txt`, content);
 			await loggingManager.sendEventLog(
 				this.client,
 				guild,
@@ -94,7 +94,7 @@ export default class extends Event {
 					message,
 					channel,
 				}),
-				`${__dirname}/../../../files/MESSAGE_DELETE-${guild?.id}.txt`,
+				`${__dirname}/../../../files/MESSAGE_DELETE-${guild.id}.txt`,
 			);
 		} else await loggingManager.sendEventLog(this.client, guild, "message", msg, embeds ? embeds : null);
 	}

--- a/src/events/message/messageDelete.ts
+++ b/src/events/message/messageDelete.ts
@@ -38,7 +38,7 @@ export default class extends Event {
 			attachment = dbData.attachments.length > 0 ? `**A**: ${dbData.attachments.join("\n")}` : "";
 			embeds = dbData.embeds;
 		} else {
-			if (message.author.id === this.client.user!.id) return;
+			if (message.author.id === this.client.user?.id) return;
 			author = message.author;
 			channel = message.channel as TextBasedChannel;
 			guild = message.guild;

--- a/src/events/message/messageUpdate.ts
+++ b/src/events/message/messageUpdate.ts
@@ -28,7 +28,7 @@ export default class extends Event {
 			if (dbData === undefined) return;
 			oldMessageContent = dbData.content;
 		} else {
-			if (newMessage.author.id === this.client.user!.id) return;
+			if (newMessage.author.id === this.client.user?.id) return;
 			if (oldMessage.content === newMessage.content) return;
 
 			const context: CommandContext = await getCommandContext(newMessage);

--- a/src/events/message/messageUpdate.ts
+++ b/src/events/message/messageUpdate.ts
@@ -49,7 +49,7 @@ export default class extends Event {
 		});
 
 		if (msg.length >= 1850) {
-			fs.writeFileSync(`${__dirname}/../../../files/MESSAGE_UPDATE-${newMessage.guild?.id}.txt`, `**B:** ${oldMessageContent}\n**A:** ${newMessage.content}`);
+			fs.writeFileSync(`${__dirname}/../../../files/MESSAGE_UPDATE-${newMessage.guild.id}.txt`, `**B:** ${oldMessageContent}\n**A:** ${newMessage.content}`);
 			await loggingManager.sendEventLog(
 				this.client,
 				newMessage.guild,
@@ -60,7 +60,7 @@ export default class extends Event {
 					message: newMessage,
 					channel: newMessage.channel,
 				}),
-				`${__dirname}/../../../files/MESSAGE_UPDATE-${newMessage.guild?.id}.txt`,
+				`${__dirname}/../../../files/MESSAGE_UPDATE-${newMessage.guild.id}.txt`,
 			);
 		} else await loggingManager.sendEventLog(this.client, newMessage.guild, "message", msg);
 

--- a/src/interactions/context/clean.ts
+++ b/src/interactions/context/clean.ts
@@ -20,7 +20,7 @@ export default async function (client: BulbBotClient, interaction: ContextMenuIn
 	if (amount - a !== 0) deleteMsg.push(amount - a);
 
 	if (!("name" in message.channel) || !message.guild) return;
-	let delMsgs = `Message purge in #${message.channel?.name} (${message.channel.id}) by ${message.author.tag} (${message.author.id}) at ${moment().format("MMMM Do YYYY, h:mm:ss a")} \n`;
+	let delMsgs = `Message purge in #${message.channel.name} (${message.channel.id}) by ${message.author.tag} (${message.author.id}) at ${moment().format("MMMM Do YYYY, h:mm:ss a")} \n`;
 
 	const messagesToPurge: Snowflake[] = [];
 	amount = 0;
@@ -41,11 +41,11 @@ export default async function (client: BulbBotClient, interaction: ContextMenuIn
 
 	await message.channel.bulkDelete(messagesToPurge);
 
-	fs.writeFile(`${__dirname}/../../../files/PURGE-${message.guild?.id}.txt`, delMsgs, function (err) {
+	fs.writeFile(`${__dirname}/../../../files/PURGE-${message.guild.id}.txt`, delMsgs, function (err) {
 		if (err) console.error(err);
 	});
 
-	await loggingManager.sendModActionFile(client, message.guild, "Purge", amount, `${__dirname}/../../../files/PURGE-${message.guild?.id}.txt`, message.channel, message.author);
+	await loggingManager.sendModActionFile(client, message.guild, "Purge", amount, `${__dirname}/../../../files/PURGE-${message.guild.id}.txt`, message.channel, message.author);
 
-	await interaction.reply({ content: await client.bulbutils.translate("purge_success", message.guild?.id, { count: amount }), ephemeral: true });
+	await interaction.reply({ content: await client.bulbutils.translate("purge_success", message.guild.id, { count: amount }), ephemeral: true });
 }

--- a/src/interactions/context/clean.ts
+++ b/src/interactions/context/clean.ts
@@ -1,5 +1,5 @@
 import BulbBotClient from "../../structures/BulbBotClient";
-import { Collection, ContextMenuInteraction, Guild, Message, Snowflake, TextChannel } from "discord.js";
+import { Collection, ContextMenuInteraction, Message, Snowflake } from "discord.js";
 import moment from "moment";
 import fs from "fs";
 import LoggingManager from "../../utils/managers/LoggingManager";
@@ -19,7 +19,8 @@ export default async function (client: BulbBotClient, interaction: ContextMenuIn
 	}
 	if (amount - a !== 0) deleteMsg.push(amount - a);
 
-	let delMsgs = `Message purge in #${(<TextChannel>message.channel).name} (${message.channel.id}) by ${message.author.tag} (${message.author.id}) at ${moment().format("MMMM Do YYYY, h:mm:ss a")} \n`;
+	if (!("name" in message.channel) || !message.guild) return;
+	let delMsgs = `Message purge in #${message.channel?.name} (${message.channel.id}) by ${message.author.tag} (${message.author.id}) at ${moment().format("MMMM Do YYYY, h:mm:ss a")} \n`;
 
 	const messagesToPurge: Snowflake[] = [];
 	amount = 0;
@@ -38,13 +39,13 @@ export default async function (client: BulbBotClient, interaction: ContextMenuIn
 		});
 	}
 
-	await (<TextChannel>message.channel).bulkDelete(messagesToPurge);
+	await message.channel.bulkDelete(messagesToPurge);
 
 	fs.writeFile(`${__dirname}/../../../files/PURGE-${message.guild?.id}.txt`, delMsgs, function (err) {
 		if (err) console.error(err);
 	});
 
-	await loggingManager.sendModActionFile(client, <Guild>message.guild, "Purge", amount, `${__dirname}/../../../files/PURGE-${message.guild?.id}.txt`, message.channel, message.author);
+	await loggingManager.sendModActionFile(client, message.guild, "Purge", amount, `${__dirname}/../../../files/PURGE-${message.guild?.id}.txt`, message.channel, message.author);
 
 	await interaction.reply({ content: await client.bulbutils.translate("purge_success", message.guild?.id, { count: amount }), ephemeral: true });
 }

--- a/src/interactions/context/infSearch.ts
+++ b/src/interactions/context/infSearch.ts
@@ -1,17 +1,17 @@
-import { ContextMenuInteraction, Message, MessageActionRow, MessageSelectMenu, Snowflake, User } from "discord.js";
+import { ContextMenuInteraction, Message, MessageActionRow, MessageSelectMenu, User } from "discord.js";
 import BulbBotClient from "../../structures/BulbBotClient";
 import InfractionsManager from "../../utils/managers/InfractionsManager";
-import { Infraction } from "../../utils/types/DatabaseStructures";
 
 const infractionManager: InfractionsManager = new InfractionsManager();
 
 export default async function (client: BulbBotClient, interaction: ContextMenuInteraction, message: Message): Promise<void> {
 	const user: User = message.author;
 
+	if (!interaction.guild) return;
 	const options: any[] = [];
-	const infs: Infraction[] = <Infraction[]>await infractionManager.getAllUserInfractions(<Snowflake>interaction.guild?.id, user.id, 0);
+	const infs = await infractionManager.getAllUserInfractions(interaction.guild.id, user.id, 0);
 
-	if (!infs.length) return interaction.reply({ content: await client.bulbutils.translate("infraction_search_not_found", interaction.guild?.id, { target: user }), ephemeral: true });
+	if (!infs?.length) return interaction.reply({ content: await client.bulbutils.translate("infraction_search_not_found", interaction.guild?.id, { target: user }), ephemeral: true });
 
 	for (let i = 0; i < 25; i++) {
 		if (infs?.[i] === undefined) continue;

--- a/src/interactions/context/infSearch.ts
+++ b/src/interactions/context/infSearch.ts
@@ -11,14 +11,14 @@ export default async function (client: BulbBotClient, interaction: ContextMenuIn
 	const options: any[] = [];
 	const infs = await infractionManager.getAllUserInfractions(interaction.guild.id, user.id, 0);
 
-	if (!infs?.length) return interaction.reply({ content: await client.bulbutils.translate("infraction_search_not_found", interaction.guild?.id, { target: user }), ephemeral: true });
+	if (!infs?.length) return interaction.reply({ content: await client.bulbutils.translate("infraction_search_not_found", interaction.guild.id, { target: user }), ephemeral: true });
 
 	for (let i = 0; i < 25; i++) {
-		if (infs?.[i] === undefined) continue;
+		if (infs[i] === undefined) continue;
 
 		options.push({
 			label: `${infs[i].action} (#${infs[i].id})`,
-			description: await client.bulbutils.translate("infraction_interaction_description", interaction.guild?.id, {}),
+			description: await client.bulbutils.translate("infraction_interaction_description", interaction.guild.id, {}),
 			value: `inf_${infs[i].id}`,
 			emoji: client.bulbutils.formatAction(infs[i].action),
 		});
@@ -26,13 +26,13 @@ export default async function (client: BulbBotClient, interaction: ContextMenuIn
 
 	const row = new MessageActionRow().addComponents(
 		new MessageSelectMenu()
-			.setPlaceholder(await client.bulbutils.translate("infraction_interaction_placeholder", interaction.guild?.id, {}))
+			.setPlaceholder(await client.bulbutils.translate("infraction_interaction_placeholder", interaction.guild.id, {}))
 			.setCustomId("infraction")
 			.addOptions(options),
 	);
 
 	await interaction.reply({
-		content: await client.bulbutils.translate("infraction_interaction_reply", interaction.guild?.id, {
+		content: await client.bulbutils.translate("infraction_interaction_reply", interaction.guild.id, {
 			target: user,
 		}),
 		components: [row],

--- a/src/interactions/context/mute.ts
+++ b/src/interactions/context/mute.ts
@@ -42,8 +42,8 @@ export default async function (client: BulbBotClient, interaction: ContextMenuIn
 			message.guild,
 			target,
 			interaction.member as GuildMember,
-			await client.bulbutils.translate("global_mod_action_log", message.guild?.id, {
-				action: await client.bulbutils.translate("mod_action_types.mute", message.guild?.id, {}),
+			await client.bulbutils.translate("global_mod_action_log", message.guild.id, {
+				action: await client.bulbutils.translate("mod_action_types.mute", message.guild.id, {}),
 				moderator: message.author,
 				target: target.user,
 				reason,

--- a/src/interactions/context/mute.ts
+++ b/src/interactions/context/mute.ts
@@ -1,4 +1,4 @@
-import { ContextMenuInteraction, Guild, GuildMember, Message, MessageActionRow, MessageSelectMenu, MessageSelectOptionData, SelectMenuInteraction, Snowflake } from "discord.js";
+import { ContextMenuInteraction, GuildMember, Message, MessageActionRow, MessageSelectMenu, MessageSelectOptionData, SelectMenuInteraction } from "discord.js";
 import moment from "moment";
 import BulbBotClient from "../../structures/BulbBotClient";
 import InfractionsManager from "../../utils/managers/InfractionsManager";
@@ -8,8 +8,9 @@ const infractionsManager: InfractionsManager = new InfractionsManager();
 const databaseManager: DatabaseManager = new DatabaseManager();
 
 export default async function (client: BulbBotClient, interaction: ContextMenuInteraction, message: Message): Promise<void> {
-	const target: GuildMember = <GuildMember>message.member;
-	const timezone = client.bulbutils.timezones[await databaseManager.getTimezone(<Snowflake>message.guild?.id)];
+	if (!message.member || !message.guild || !interaction.member) return;
+	const target = message.member;
+	const timezone = client.bulbutils.timezones[await databaseManager.getTimezone(message.guild.id)];
 	const reason = await client.bulbutils.translate("global_no_reason", interaction.guild?.id, {});
 
 	const reasons: string[] = (await databaseManager.getConfig(target.guild.id)).quickReasons;
@@ -34,13 +35,13 @@ export default async function (client: BulbBotClient, interaction: ContextMenuIn
 	const collector = interaction.channel?.createMessageComponentCollector({ componentType: "SELECT_MENU", time: 30000 });
 
 	collector?.on("collect", async (i: SelectMenuInteraction) => {
-		if (interaction.user.id !== i.user.id) return;
+		if (interaction.user.id !== i.user.id || !message.guild || !interaction.member) return;
 
 		const infID = await infractionsManager.mute(
 			client,
-			<Guild>message.guild,
+			message.guild,
 			target,
-			<GuildMember>interaction.member,
+			interaction.member as GuildMember,
 			await client.bulbutils.translate("global_mod_action_log", message.guild?.id, {
 				action: await client.bulbutils.translate("mod_action_types.mute", message.guild?.id, {}),
 				moderator: message.author,

--- a/src/interactions/context/warn.ts
+++ b/src/interactions/context/warn.ts
@@ -35,7 +35,7 @@ export default async function (client: BulbBotClient, interaction: ContextMenuIn
 
 		const infID = await infractionsManager.warn(
 			client,
-			interaction.guild?.id,
+			interaction.guild.id,
 			target.user,
 			interaction.member as GuildMember,
 			await client.bulbutils.translate("global_mod_action_log", message.guild?.id, {
@@ -48,8 +48,8 @@ export default async function (client: BulbBotClient, interaction: ContextMenuIn
 		);
 
 		await i.update({
-			content: await client.bulbutils.translate("action_success", interaction.guild?.id, {
-				action: await client.bulbutils.translate("mod_action_types.warn", interaction.guild?.id, {}),
+			content: await client.bulbutils.translate("action_success", interaction.guild.id, {
+				action: await client.bulbutils.translate("mod_action_types.warn", interaction.guild.id, {}),
 				target: message.author,
 				moderator: interaction.user,
 				reason: i.values[0],

--- a/src/interactions/context/warn.ts
+++ b/src/interactions/context/warn.ts
@@ -1,5 +1,5 @@
 import BulbBotClient from "../../structures/BulbBotClient";
-import { ContextMenuInteraction, GuildMember, Message, MessageActionRow, MessageSelectMenu, MessageSelectOptionData, SelectMenuInteraction, Snowflake } from "discord.js";
+import { ContextMenuInteraction, GuildMember, Message, MessageActionRow, MessageSelectMenu, MessageSelectOptionData, SelectMenuInteraction } from "discord.js";
 import InfractionsManager from "../../utils/managers/InfractionsManager";
 import DatabaseManager from "../../utils/managers/DatabaseManager";
 
@@ -7,9 +7,10 @@ const infractionsManager: InfractionsManager = new InfractionsManager();
 const databaseManager: DatabaseManager = new DatabaseManager();
 
 export default async function (client: BulbBotClient, interaction: ContextMenuInteraction, message: Message): Promise<void> {
-	const target: GuildMember = <GuildMember>message.member;
+	const target = message.member;
+	if (!target || !interaction.guild) return;
 	const reasons: string[] = (await databaseManager.getConfig(target.guild.id)).quickReasons;
-	reasons.push(await client.bulbutils.translate("global_no_reason", interaction.guild?.id, {}));
+	reasons.push(await client.bulbutils.translate("global_no_reason", interaction.guild.id, {}));
 
 	const options: MessageSelectOptionData[] = [];
 	for (const reason of reasons) {
@@ -19,9 +20,9 @@ export default async function (client: BulbBotClient, interaction: ContextMenuIn
 	const row: MessageActionRow = new MessageActionRow().addComponents(new MessageSelectMenu().setPlaceholder("Select a reason").setCustomId("warn").addOptions(options));
 
 	await interaction.reply({
-		content: await client.bulbutils.translate("userinfo_interaction_confirm", interaction.guild?.id, {
+		content: await client.bulbutils.translate("userinfo_interaction_confirm", interaction.guild.id, {
 			target: target.user,
-			action: await client.bulbutils.translate("mod_action_types.warn", interaction.guild?.id, {}),
+			action: await client.bulbutils.translate("mod_action_types.warn", interaction.guild.id, {}),
 		}),
 		components: [row],
 		ephemeral: true,
@@ -30,13 +31,13 @@ export default async function (client: BulbBotClient, interaction: ContextMenuIn
 	const collector = interaction.channel?.createMessageComponentCollector({ componentType: "SELECT_MENU", time: 30000 });
 
 	collector?.on("collect", async (i: SelectMenuInteraction) => {
-		if (interaction.user.id !== i.user.id) return;
+		if (interaction.user.id !== i.user.id || !interaction.guild || !interaction.member) return;
 
 		const infID = await infractionsManager.warn(
 			client,
-			<Snowflake>interaction.guild?.id,
+			interaction.guild?.id,
 			target.user,
-			<GuildMember>interaction.member,
+			interaction.member as GuildMember,
 			await client.bulbutils.translate("global_mod_action_log", message.guild?.id, {
 				action: await client.bulbutils.translate("mod_action_types.warn", message.guild?.id, {}),
 				moderator: interaction.user,

--- a/src/interactions/select/infraction.ts
+++ b/src/interactions/select/infraction.ts
@@ -1,21 +1,21 @@
 import { NonDigits, ReasonImage } from "../../utils/Regex";
-import { MessageEmbed, SelectMenuInteraction, Snowflake } from "discord.js";
+import { MessageEmbed, SelectMenuInteraction } from "discord.js";
 import moment from "moment";
 import * as Emotes from "../../emotes.json";
 import { embedColor } from "../../Config";
 import BulbBotClient from "../../structures/BulbBotClient";
 import InfractionsManager from "../../utils/managers/InfractionsManager";
-import { Infraction } from "../../utils/types/DatabaseStructures";
 
 const infractionsManager: InfractionsManager = new InfractionsManager();
 
 export default async function (client: BulbBotClient, interaction: SelectMenuInteraction): Promise<void> {
+	if (!interaction.guild) return;
 	const infID = Number(interaction.values[0].replace(NonDigits, ""));
-	const inf: Infraction = <Infraction>await infractionsManager.getInfraction(<Snowflake>interaction.guild?.id, infID);
+	const inf = await infractionsManager.getInfraction(interaction.guild.id, infID);
 
 	if (!inf)
 		return interaction.reply({
-			content: await client.bulbutils.translate("infraction_not_found", interaction.guild?.id, {
+			content: await client.bulbutils.translate("infraction_not_found", interaction.guild.id, {
 				infraction_id: infID,
 			}),
 			ephemeral: true,
@@ -26,24 +26,24 @@ export default async function (client: BulbBotClient, interaction: SelectMenuInt
 	const moderator: Record<string, string> = { tag: inf.moderator, id: inf.moderatorId };
 
 	let description = "";
-	description += await client.bulbutils.translate("infraction_info_inf_id", interaction.guild?.id, { infraction_id: inf.id });
-	description += await client.bulbutils.translate("infraction_info_target", interaction.guild?.id, { target });
-	description += await client.bulbutils.translate("infraction_info_moderator", interaction.guild?.id, { moderator });
-	description += await client.bulbutils.translate("infraction_info_created", interaction.guild?.id, {
+	description += await client.bulbutils.translate("infraction_info_inf_id", interaction.guild.id, { infraction_id: inf.id });
+	description += await client.bulbutils.translate("infraction_info_target", interaction.guild.id, { target });
+	description += await client.bulbutils.translate("infraction_info_moderator", interaction.guild.id, { moderator });
+	description += await client.bulbutils.translate("infraction_info_created", interaction.guild.id, {
 		created: moment(Date.parse(inf.createdAt)).format("MMM Do YYYY, h:mm:ss a"),
 	});
 
 	if (inf.active !== "false" && inf.active !== "true") {
-		description += await client.bulbutils.translate("infraction_info_expires", interaction.guild?.id, {
+		description += await client.bulbutils.translate("infraction_info_expires", interaction.guild.id, {
 			expires: `${Emotes.status.ONLINE} ${moment(parseInt(inf.active)).format("MMM Do YYYY, h:mm:ss a")}`,
 		});
 	} else {
-		description += await client.bulbutils.translate("infraction_info_active", interaction.guild?.id, {
+		description += await client.bulbutils.translate("infraction_info_active", interaction.guild.id, {
 			active: client.bulbutils.prettify(inf.active),
 		});
 	}
 
-	description += await client.bulbutils.translate("infraction_info_reason", interaction.guild?.id, { reason: inf.reason });
+	description += await client.bulbutils.translate("infraction_info_reason", interaction.guild.id, { reason: inf.reason });
 
 	const image = inf.reason.match(ReasonImage);
 
@@ -54,7 +54,7 @@ export default async function (client: BulbBotClient, interaction: SelectMenuInt
 		.setImage(image ? image[0] : "")
 		.setThumbnail(user?.avatarUrl || "")
 		.setFooter({
-			text: await client.bulbutils.translate("global_executed_by", interaction.guild?.id, { user: interaction.user }),
+			text: await client.bulbutils.translate("global_executed_by", interaction.guild.id, { user: interaction.user }),
 			iconURL: interaction.user.avatarURL({ dynamic: true }) ?? undefined,
 		})
 		.setTimestamp();

--- a/src/interactions/select/infraction.ts
+++ b/src/interactions/select/infraction.ts
@@ -51,11 +51,11 @@ export default async function (client: BulbBotClient, interaction: SelectMenuInt
 		.setTitle(client.bulbutils.prettify(inf.action))
 		.setDescription(description)
 		.setColor(embedColor)
-		.setImage(<string>(image ? image[0] : null))
-		.setThumbnail(user.avatarUrl)
+		.setImage(image ? image[0] : "")
+		.setThumbnail(user?.avatarUrl || "")
 		.setFooter({
 			text: await client.bulbutils.translate("global_executed_by", interaction.guild?.id, { user: interaction.user }),
-			iconURL: <string>interaction.user.avatarURL({ dynamic: true }),
+			iconURL: interaction.user.avatarURL({ dynamic: true }) ?? undefined,
 		})
 		.setTimestamp();
 

--- a/src/interactions/select/reminders.ts
+++ b/src/interactions/select/reminders.ts
@@ -34,7 +34,7 @@ export default async function (client: BulbBotClient, interaction: SelectMenuInt
 			text: await client.bulbutils.translate("global_executed_by", interaction.guild?.id, {
 				user: interaction.user,
 			}),
-			iconURL: <string>interaction.user.avatarURL({ dynamic: true }),
+			iconURL: interaction.user.avatarURL({ dynamic: true }) ?? undefined,
 		})
 		.setTimestamp();
 

--- a/src/structures/AutoModCache.ts
+++ b/src/structures/AutoModCache.ts
@@ -1,5 +1,5 @@
 import BulbBotClient from "./BulbBotClient";
-import { DMChannel, Guild, Snowflake } from "discord.js";
+import { DMChannel, Snowflake } from "discord.js";
 import AutoModManager from "../utils/managers/AutoModManager";
 import LoggingManager from "../utils/managers/LoggingManager";
 import DatabaseManager from "../utils/managers/DatabaseManager";
@@ -12,6 +12,7 @@ const databaseManager: DatabaseManager = new DatabaseManager();
 const cache = {};
 
 export async function set(client: BulbBotClient, context: CommandContext, guild: Snowflake, category: "mentions" | "messages", user: Snowflake, value: number, timeout = 10000): Promise<void> {
+	if (!context.guild) return;
 	if (cache[guild] === undefined) cache[guild] = { mentions: {}, messages: {} };
 
 	if (!cache[guild][category][user]) cache[guild][category][user] = { count: value, time: Date.now() };
@@ -28,7 +29,7 @@ export async function set(client: BulbBotClient, context: CommandContext, guild:
 				client,
 				context,
 				dbGuild.punishmentMessages,
-				await client.bulbutils.translate("automod_violation_max_messages_reason", context.guild?.id, {
+				await client.bulbutils.translate("automod_violation_max_messages_reason", context.guild.id, {
 					channel: context.channel,
 					amount: cache[guild]["messages"][user]["count"],
 					limit: dbGuild.timeoutMessages,
@@ -37,8 +38,8 @@ export async function set(client: BulbBotClient, context: CommandContext, guild:
 		}
 		await loggingManager.sendAutoModLog(
 			client,
-			<Guild>context.guild,
-			await client.bulbutils.translate("automod_violation_max_messages_log", context.guild?.id, {
+			context.guild,
+			await client.bulbutils.translate("automod_violation_max_messages_log", context.guild.id, {
 				target: context.author,
 				channel: context.channel,
 				amount: cache[guild]["messages"][user]["count"],
@@ -53,7 +54,7 @@ export async function set(client: BulbBotClient, context: CommandContext, guild:
 				client,
 				context,
 				dbGuild.punishmentMentions,
-				await client.bulbutils.translate("automod_violation_max_mentions_reason", context.guild?.id, {
+				await client.bulbutils.translate("automod_violation_max_mentions_reason", context.guild.id, {
 					channel: context.channel,
 					amount: cache[guild]["mentions"][user]["count"],
 					limit: dbGuild.timeoutMentions,
@@ -62,8 +63,8 @@ export async function set(client: BulbBotClient, context: CommandContext, guild:
 		}
 		await loggingManager.sendAutoModLog(
 			client,
-			<Guild>context.guild,
-			await client.bulbutils.translate("automod_violation_max_mentions_log", context.guild?.id, {
+			context.guild,
+			await client.bulbutils.translate("automod_violation_max_mentions_log", context.guild.id, {
 				target: context.author,
 				channel: context.channel,
 				amount: cache[guild]["mentions"][user]["count"],

--- a/src/structures/BulbBotClient.ts
+++ b/src/structures/BulbBotClient.ts
@@ -85,6 +85,6 @@ export default class extends Client {
 		await this.utils.loadBlacklist();
 		await this.utils.loadAbout();
 
-		await super.login(<string>token);
+		await super.login(token as string);
 	}
 }

--- a/src/structures/CommandContext.ts
+++ b/src/structures/CommandContext.ts
@@ -1007,7 +1007,7 @@ class InteractionCommandContext implements BaseCommandContext {
 						if (typeof content === "object" && "embeds" in content) {
 							e = await this.editReply({ ...content, embeds: content.embeds ?? undefined });
 						} else {
-							e = await this.editReply(<string | MessagePayload>content);
+							e = await this.editReply(content as string | MessagePayload);
 						}
 						// @ts-expect-error
 						return e instanceof Message ? e : new Message(this.client, e);

--- a/src/structures/CommandContext.ts
+++ b/src/structures/CommandContext.ts
@@ -451,7 +451,7 @@ class MessageCommandContext implements BaseCommandContext {
 		this._prefix = null;
 		this.client = source.client;
 		this.channel = clone(source.channel);
-		this.channelId = this.channel?.id ?? null;
+		this.channelId = this.channel.id ?? null;
 		this.guild = source.guild;
 		this.guildId = source.guildId;
 		this.createdAt = source.createdAt;
@@ -628,7 +628,7 @@ class InteractionCommandContext implements BaseCommandContext {
 	public webhook: InteractionWebhook | null;
 	public get ephemeral(): boolean | null {
 		// @ts-expect-error
-		return this.source?.ephemeral ?? null;
+		return this.source.ephemeral ?? null;
 	}
 	public set ephemeral(e: boolean | null) {
 		// @ts-expect-error
@@ -821,7 +821,7 @@ class InteractionCommandContext implements BaseCommandContext {
 		// Nah this is funny
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 		this.channel = source.channel ? clone(source.channel) : null!;
-		this.channelId = this.channel?.id ?? source.channelId;
+		this.channelId = this.channel.id ?? source.channelId;
 		this.guild = source.guild;
 		this.guildId = source.guildId;
 		this.createdAt = source.createdAt;

--- a/src/structures/Util.ts
+++ b/src/structures/Util.ts
@@ -69,7 +69,7 @@ export default class {
 					try {
 						await event.run(...args);
 					} catch (err: any) {
-						await this.client.bulbutils.logError(err, undefined, event?.name ?? name ?? eventFile ?? "Unknown Event", args);
+						await this.client.bulbutils.logError(err, undefined, event.name ?? name ?? eventFile ?? "Unknown Event", args);
 					}
 				});
 			}

--- a/src/structures/Util.ts
+++ b/src/structures/Util.ts
@@ -26,7 +26,7 @@ export default class {
 	}
 
 	get directory(): string {
-		return `${path.dirname(<string>require.main?.filename)}${path.sep}`;
+		return `${path.dirname(require.main?.filename || ".")}${path.sep}`;
 	}
 
 	async loadCommands(): Promise<void> {

--- a/src/utils/AutoMod.ts
+++ b/src/utils/AutoMod.ts
@@ -19,7 +19,9 @@ export default async function (client: BulbBotClient, context: CommandContext): 
 	if (!dbGuild.enabled) return;
 	if (context.member?.permissions.has(Permissions.FLAGS.MANAGE_MESSAGES)) return;
 	if (dbGuild.ignoreUsers.includes(context.author.id)) return;
-	if (dbGuild.ignoreChannels.includes(context.channel.id) || ((<GuildChannel>context.channel).parent && dbGuild.ignoreChannels.includes((<GuildChannel>context.channel).parent!.id))) return;
+	// We are checking for undefined before using this value, but due to the typecast the type doesn't get narrowed
+	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+	if (dbGuild.ignoreChannels.includes(context.channel.id) || ((<GuildChannel>context.channel).parent && dbGuild.ignoreChannels.includes((context.channel as GuildChannel).parent!.id))) return;
 
 	if (!context.member?.roles.cache.values()) return;
 	for (const role of context.member.roles.cache.values()) {

--- a/src/utils/BulbBotFetch.ts
+++ b/src/utils/BulbBotFetch.ts
@@ -16,9 +16,9 @@ export default class {
 		return user;
 	}
 
-	public async getGuildMember(members: GuildMemberManager | undefined, userId: Snowflake): Promise<GuildMember | undefined> {
+	public async getGuildMember(members: GuildMemberManager | undefined, userId: Snowflake | undefined): Promise<GuildMember | undefined> {
+		if (!userId) return undefined;
 		let member: GuildMember | undefined = members?.cache.get(userId);
-		if (!userId.length) return undefined;
 		if (!member) member = await members?.fetch(userId).catch((_) => undefined);
 
 		return member;

--- a/src/utils/BulbBotUtils.ts
+++ b/src/utils/BulbBotUtils.ts
@@ -222,9 +222,9 @@ export default class {
 	public checkUser(context: CommandContext, user: GuildMember): UserHandle {
 		if (
 			context.author.id === context.guild?.ownerId &&
-			context.guild?.me &&
-			context.guild?.me.roles.highest.id !== user.roles.highest.id &&
-			user.roles.highest.rawPosition < context.guild?.me.roles.highest.rawPosition
+			context.guild.me &&
+			context.guild.me.roles.highest.id !== user.roles.highest.id &&
+			user.roles.highest.rawPosition < context.guild.me.roles.highest.rawPosition
 		)
 			return UserHandle.SUCCESS;
 
@@ -236,11 +236,11 @@ export default class {
 
 		if (user.id === this.client.user?.id) return UserHandle.CANNOT_ACTION_BOT_SELF;
 
-		if (context.member?.roles && user.roles.highest.rawPosition >= context.member?.roles.highest.rawPosition) return UserHandle.CANNOT_ACTION_ROLE_HIGHER;
+		if (context.member?.roles && user.roles.highest.rawPosition >= context.member.roles.highest.rawPosition) return UserHandle.CANNOT_ACTION_ROLE_HIGHER;
 
-		if (context.guild?.me && context.guild?.me.roles.highest.id === user.roles.highest.id) return UserHandle.CANNOT_ACTION_USER_ROLE_EQUAL_BOT;
+		if (context.guild?.me && context.guild.me.roles.highest.id === user.roles.highest.id) return UserHandle.CANNOT_ACTION_USER_ROLE_EQUAL_BOT;
 
-		if (context.guild?.me && user.roles.highest.rawPosition >= context.guild?.me.roles.highest.rawPosition) return UserHandle.CANNOT_ACTION_USER_ROLE_HIGHER_BOT;
+		if (context.guild?.me && user.roles.highest.rawPosition >= context.guild.me.roles.highest.rawPosition) return UserHandle.CANNOT_ACTION_USER_ROLE_HIGHER_BOT;
 
 		return UserHandle.SUCCESS;
 	}
@@ -267,9 +267,9 @@ export default class {
 
 		if (
 			interaction.user.id === interaction.guild?.ownerId &&
-			interaction.guild?.me &&
-			interaction.guild?.me.roles.highest.id !== user.roles.highest.id &&
-			user.roles.highest.rawPosition < interaction.guild?.me.roles.highest.rawPosition
+			interaction.guild.me &&
+			interaction.guild.me.roles.highest.id !== user.roles.highest.id &&
+			user.roles.highest.rawPosition < interaction.guild.me.roles.highest.rawPosition
 		)
 			return UserHandle.SUCCESS;
 
@@ -277,11 +277,11 @@ export default class {
 
 		if (user.id === this.client.user?.id) return UserHandle.CANNOT_ACTION_BOT_SELF;
 
-		if (author?.roles && user.roles.highest.rawPosition >= author?.roles.highest.rawPosition) return UserHandle.CANNOT_ACTION_ROLE_HIGHER;
+		if (author?.roles && user.roles.highest.rawPosition >= author.roles.highest.rawPosition) return UserHandle.CANNOT_ACTION_ROLE_HIGHER;
 
-		if (interaction.guild?.me && interaction.guild?.me.roles.highest.id === user.roles.highest.id) return UserHandle.CANNOT_ACTION_USER_ROLE_EQUAL_BOT;
+		if (interaction.guild?.me && interaction.guild.me.roles.highest.id === user.roles.highest.id) return UserHandle.CANNOT_ACTION_USER_ROLE_EQUAL_BOT;
 
-		if (interaction.guild?.me && user.roles.highest.rawPosition >= interaction.guild?.me?.roles.highest.rawPosition) return UserHandle.CANNOT_ACTION_USER_ROLE_HIGHER_BOT;
+		if (interaction.guild?.me && user.roles.highest.rawPosition >= interaction.guild.me.roles.highest.rawPosition) return UserHandle.CANNOT_ACTION_USER_ROLE_HIGHER_BOT;
 
 		return UserHandle.SUCCESS;
 	}
@@ -400,7 +400,7 @@ export default class {
 			.setDescription(`**Stack trace:** \n\`\`\`${err.stack}\`\`\``);
 
 		if (context) {
-			embed.addField("Guild ID", `${context?.guild?.id}`, true);
+			embed.addField("Guild ID", `${context.guild?.id}`, true);
 			embed.addField("User", context.author.id, true);
 			embed.addField("Message Content", context.content, true);
 		} else if (runArgs) {
@@ -415,7 +415,7 @@ export default class {
 								v?.channel && v?.channel?.name
 									? "\n*Channel:* " + v?.channel.name + " <#" + v?.channel.id + "> (`" + v?.channel.id + ")`"
 									: v instanceof GuildChannel
-									? "\n*Channel:* <#" + v?.id + "> #" + v?.name + " (`" + v?.id + ")`"
+									? "\n*Channel:* <#" + v.id + "> #" + v.name + " (`" + v.id + ")`"
 									: ""
 						  }`
 						: "";

--- a/src/utils/BulbBotUtils.ts
+++ b/src/utils/BulbBotUtils.ts
@@ -1,4 +1,4 @@
-import { ContextMenuInteraction, GuildChannel, GuildMember, MessageEmbed, Snowflake, TextChannel, ThreadAutoArchiveDuration, ThreadChannel, User } from "discord.js";
+import { ContextMenuInteraction, GuildChannel, GuildMember, MessageEmbed, Snowflake, ThreadAutoArchiveDuration, ThreadChannel, User } from "discord.js";
 import * as Emotes from "../emotes.json";
 import moment, { Duration, Moment } from "moment";
 import CommandContext from "../structures/CommandContext";
@@ -400,26 +400,22 @@ export default class {
 			.setDescription(`**Stack trace:** \n\`\`\`${err.stack}\`\`\``);
 
 		if (context) {
-			embed.addField("Guild ID", <string>context?.guild?.id, true);
-			embed.addField("User", <string>context.author.id, true);
-			embed.addField("Message Content", <string>context.content, true);
+			embed.addField("Guild ID", `${context?.guild?.id}`, true);
+			embed.addField("User", context.author.id, true);
+			embed.addField("Message Content", context.content, true);
 		} else if (runArgs) {
 			const argsDesc: string[] = [];
-			for (const [k, v] of Object.entries(runArgs)) {
-				if ((<any>v)?.inviter) (<any>v).user = (<any>v).inviter;
+			for (const [k, v] of Object.entries<any>(runArgs)) {
+				if (v?.inviter) v.user = v.inviter;
 				const additionalInfo =
 					typeof v === "object"
-						? `${(<any>v)?.guild.name ? "\n*Guild:* " + (<any>v)?.guild.name + " (`" + (<any>v)?.guild.id + "`)" : ""}${
-								(<any>v)?.member
-									? "\n*Member*: " + (<any>v)?.member.user.tag + " <@" + (<any>v)?.member.id + ">"
-									: (<any>v)?.user
-									? "\n*User:* " + (<any>v)?.user.tag + " <@" + (<any>v)?.user.id + ">"
-									: ""
+						? `${v?.guild.name ? "\n*Guild:* " + v?.guild.name + " (`" + v?.guild.id + "`)" : ""}${
+								v?.member ? "\n*Member*: " + v?.member.user.tag + " <@" + v?.member.id + ">" : v?.user ? "\n*User:* " + v?.user.tag + " <@" + v?.user.id + ">" : ""
 						  }${
-								(<any>v)?.channel && (<any>v)?.channel?.name
-									? "\n*Channel:* " + (<any>v)?.channel.name + " <#" + (<any>v)?.channel.id + "> (`" + (<any>v)?.channel.id + ")`"
+								v?.channel && v?.channel?.name
+									? "\n*Channel:* " + v?.channel.name + " <#" + v?.channel.id + "> (`" + v?.channel.id + ")`"
 									: v instanceof GuildChannel
-									? "\n*Channel:* <#" + (<any>v)?.id + "> #" + (<any>v)?.name + " (`" + (<any>v)?.id + ")`"
+									? "\n*Channel:* <#" + v?.id + "> #" + v?.name + " (`" + v?.id + ")`"
 									: ""
 						  }`
 						: "";
@@ -429,7 +425,8 @@ export default class {
 			embed.addField("Event Arguments", argsDesc.join("\n").slice(0, 1024));
 		}
 
-		await (<TextChannel>this.client.channels.cache.get(error)).send({ embeds: [embed] });
+		const errorChannel = this.client.channels.cache.get(error);
+		errorChannel?.isText() && (await errorChannel.send({ embeds: [embed] }));
 	}
 
 	/** Return a list of property keys where the values differ between the two objects */

--- a/src/utils/Prometheus.ts
+++ b/src/utils/Prometheus.ts
@@ -1,7 +1,8 @@
 import prom from "prom-client";
 import http from "http";
-import url from "url";
+import { URL } from "url";
 import Command from "../structures/Command";
+import { tryIgnore } from "./helpers";
 
 const latency = new prom.Gauge({ name: "bulbbot_latency", help: "The bulbbot latency to the Discord Websocket" });
 const cachedUsers = new prom.Gauge({ name: "bulbbot_cached_users", help: "The amount of cached users in the memory" });
@@ -53,7 +54,7 @@ export async function startPrometheus(client: any): Promise<void> {
 	});
 
 	const server = http.createServer(async (req, res) => {
-		const route = url.parse(req.url!).pathname;
+		const route = tryIgnore(() => new URL(req.url || "").pathname);
 
 		if (route === "/metrics") {
 			res.setHeader("Content-Type", register.contentType);

--- a/src/utils/Restoration.ts
+++ b/src/utils/Restoration.ts
@@ -93,7 +93,7 @@ export default class {
 			}
 
 			setTimeout(async function () {
-				if (!guild?.me) return;
+				if (!guild.me) return;
 
 				await tryIgnore(
 					infractionsManager.unban,
@@ -101,9 +101,9 @@ export default class {
 					guild,
 					BanType.TEMP,
 					target,
-					guild?.me,
-					await client.bulbutils.translate("global_mod_action_log", guild?.id, {
-						action: await client.bulbutils.translate("mod_action_types.auto_unban", guild?.id, {}),
+					guild.me,
+					await client.bulbutils.translate("global_mod_action_log", guild.id, {
+						action: await client.bulbutils.translate("mod_action_types.auto_unban", guild.id, {}),
 						moderator: client.user,
 						target: target,
 						reason: "Automatic unban",

--- a/src/utils/Restoration.ts
+++ b/src/utils/Restoration.ts
@@ -1,7 +1,7 @@
 import ReminderManager from "./managers/ReminderManager";
 import InfractionsManager from "./managers/InfractionsManager";
 import TempbanManager from "./managers/TempbanManager";
-import { Guild, GuildMember, Message, User } from "discord.js";
+import { Guild, Message, User } from "discord.js";
 import moment from "moment";
 import BulbBotClient from "../structures/BulbBotClient";
 import { BanType } from "./types/BanType";
@@ -78,7 +78,7 @@ export default class {
 			try {
 				guild = await client.guilds.fetch(tempban.gId);
 			} catch (_) {
-				client.log.client(`[CLIENT - TEMP BANS] [#${tempban.id}] Bot was kicked from the guild cant unban the user: ${tempban.targetId}`);
+				client.log.client(`[CLIENT - TEMP BANS] [#${tempban.id}] Bot was kicked from the guild, can't unban the user: ${tempban.targetId}`);
 				await deleteTempBan(tempban.id);
 				continue;
 			}
@@ -93,13 +93,15 @@ export default class {
 			}
 
 			setTimeout(async function () {
+				if (!guild?.me) return;
+
 				await tryIgnore(
 					infractionsManager.unban,
 					client,
-					<Guild>guild,
+					guild,
 					BanType.TEMP,
 					target,
-					<GuildMember>guild?.me,
+					guild?.me,
 					await client.bulbutils.translate("global_mod_action_log", guild?.id, {
 						action: await client.bulbutils.translate("mod_action_types.auto_unban", guild?.id, {}),
 						moderator: client.user,

--- a/src/utils/database/connection.ts
+++ b/src/utils/database/connection.ts
@@ -3,7 +3,11 @@ import * as env from "dotenv";
 import applyExtra from "./applyExtra";
 env.config({ path: `${__dirname}/../../../src/.env` });
 
-export const sequelize: Sequelize = new Sequelize(<string>process.env.DB_NAME, <string>process.env.DB_USER, <string>process.env.DB_PASSWORD, {
+if (typeof process.env.DB_NAME !== "string" || typeof process.env.DB_USER !== "string" || typeof process.env.DB_PASSWORD !== "string") {
+	throw new Error("process.env is missing required DB environment variables (is your .env configured correctly?)");
+}
+
+export const sequelize: Sequelize = new Sequelize(process.env.DB_NAME, process.env.DB_USER, process.env.DB_PASSWORD, {
 	host: process.env.DB_HOST,
 	dialect: "postgres",
 	logging: false,

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -12,3 +12,7 @@ export function tryIgnore<T extends (...args: any[]) => any>(cb: T, ...args: Par
 	} catch {}
 	return undefined;
 }
+
+export function clone<T extends object | null>(obj: T): T {
+	return Object.assign(Object.create(obj), obj);
+}

--- a/src/utils/managers/AutoModManager.ts
+++ b/src/utils/managers/AutoModManager.ts
@@ -16,10 +16,15 @@ export default class {
 			},
 		};
 
+		if (!context.guild?.id) {
+			client.log.error(`[Auto Mod Manager] Guild ID is null, reason: ${reason}, target ${target.user.tag} (${target.user.id})`);
+			return "LOG";
+		}
+
 		// action has been null in the past adding some safeguarding and just returning a LOG
 		// until we have valid repro for this
 		if (action === null) {
-			client.log.error(`[Auto Mod Manager] Action is null in ${context.guild?.id}, reason: ${reason}, target ${target.user.tag} (${target.user.id})`);
+			client.log.error(`[Auto Mod Manager] Action is null in ${context.guild.id}, reason: ${reason}, target ${target.user.tag} (${target.user.id})`);
 			return "LOG";
 		}
 
@@ -29,11 +34,11 @@ export default class {
 			case "WARN":
 				await infractionsManager.warn(
 					client,
-					<Snowflake>context.guild?.id,
+					<Snowflake>context.guild.id,
 					<User>target.user,
-					<GuildMember>context.guild?.me,
-					await client.bulbutils.translate("global_mod_action_log", context.guild?.id, {
-						action: await client.bulbutils.translate("mod_action_types.warn", context.guild?.id, {}),
+					<GuildMember>context.guild.me,
+					await client.bulbutils.translate("global_mod_action_log", context.guild.id, {
+						action: await client.bulbutils.translate("mod_action_types.warn", context.guild.id, {}),
 						moderator: client.user,
 						target: target.user,
 						reason,
@@ -42,14 +47,14 @@ export default class {
 				);
 				break;
 			case "KICK":
-				target = await client.bulbfetch.getGuildMember(context.guild?.members, context.author.id);
+				target = await client.bulbfetch.getGuildMember(context.guild.members, context.author.id);
 				await infractionsManager.kick(
 					client,
-					context.guild!.id,
+					context.guild.id,
 					target,
-					<GuildMember>context.guild?.me,
-					await client.bulbutils.translate("global_mod_action_log", context.guild?.id, {
-						action: await client.bulbutils.translate("mod_action_types.kick", context.guild?.id, {}),
+					<GuildMember>context.guild.me,
+					await client.bulbutils.translate("global_mod_action_log", context.guild.id, {
+						action: await client.bulbutils.translate("mod_action_types.kick", context.guild.id, {}),
 						moderator: client.user,
 						target: target.user,
 						reason,
@@ -63,9 +68,9 @@ export default class {
 					<Guild>context.guild,
 					BanType.CLEAN,
 					<User>target.user,
-					<GuildMember>context.guild?.me,
-					await client.bulbutils.translate("global_mod_action_log", context.guild?.id, {
-						action: await client.bulbutils.translate("mod_action_types.ban", context.guild?.id, {}),
+					<GuildMember>context.guild.me,
+					await client.bulbutils.translate("global_mod_action_log", context.guild.id, {
+						action: await client.bulbutils.translate("mod_action_types.ban", context.guild.id, {}),
 						moderator: client.user,
 						target: target.user,
 						reason,
@@ -107,7 +112,7 @@ export default class {
 			case "KICK":
 				await infractionsManager.kick(
 					client,
-					member.guild!.id,
+					member.guild.id,
 					member,
 					<GuildMember>member.guild?.me,
 					await client.bulbutils.translate("global_mod_action_log", member.guild?.id, {

--- a/src/utils/managers/AutoModManager.ts
+++ b/src/utils/managers/AutoModManager.ts
@@ -1,5 +1,5 @@
 import BulbBotClient from "../../structures/BulbBotClient";
-import { Guild, GuildMember, Snowflake, User } from "discord.js";
+import { GuildMember } from "discord.js";
 import InfractionsManager from "./InfractionsManager";
 import AutoModException from "../../structures/exceptions/AutoModException";
 import { BanType } from "../types/BanType";
@@ -16,8 +16,8 @@ export default class {
 			},
 		};
 
-		if (!context.guild?.id) {
-			client.log.error(`[Auto Mod Manager] Guild ID is null, reason: ${reason}, target ${target.user.tag} (${target.user.id})`);
+		if (!context.guild?.id || !context.guild.me) {
+			client.log.error(`[Auto Mod Manager] Guild is null, reason: ${reason}, target ${target.user.tag} (${target.user.id})`);
 			return "LOG";
 		}
 
@@ -34,9 +34,9 @@ export default class {
 			case "WARN":
 				await infractionsManager.warn(
 					client,
-					<Snowflake>context.guild.id,
-					<User>target.user,
-					<GuildMember>context.guild.me,
+					context.guild.id,
+					target.user,
+					context.guild.me,
 					await client.bulbutils.translate("global_mod_action_log", context.guild.id, {
 						action: await client.bulbutils.translate("mod_action_types.warn", context.guild.id, {}),
 						moderator: client.user,
@@ -52,7 +52,7 @@ export default class {
 					client,
 					context.guild.id,
 					target,
-					<GuildMember>context.guild.me,
+					context.guild.me,
 					await client.bulbutils.translate("global_mod_action_log", context.guild.id, {
 						action: await client.bulbutils.translate("mod_action_types.kick", context.guild.id, {}),
 						moderator: client.user,
@@ -65,10 +65,10 @@ export default class {
 			case "BAN":
 				await infractionsManager.ban(
 					client,
-					<Guild>context.guild,
+					context.guild,
 					BanType.CLEAN,
-					<User>target.user,
-					<GuildMember>context.guild.me,
+					target.user,
+					context.guild.me,
 					await client.bulbutils.translate("global_mod_action_log", context.guild.id, {
 						action: await client.bulbutils.translate("mod_action_types.ban", context.guild.id, {}),
 						moderator: client.user,
@@ -86,6 +86,11 @@ export default class {
 	}
 
 	async resolveActionWithoutContext(client: BulbBotClient, member: GuildMember, action: string, reason: string): Promise<string> {
+		if (!member.guild?.id || !member.guild.me) {
+			client.log.error(`[Auto Mod Manager] Guild is null, reason: ${reason}, target ${member.user.tag} (${member.user.id})`);
+			return "LOG";
+		}
+
 		if (action === null) {
 			client.log.error(`[Auto Mod Manager] Action is null in ${member.guild?.id}, reason: ${reason}, target ${member.user.tag} (${member.user.id})`);
 			return "LOG";
@@ -97,11 +102,11 @@ export default class {
 			case "WARN":
 				await infractionsManager.warn(
 					client,
-					<Snowflake>member.guild?.id,
+					member.guild.id,
 					member.user,
-					<GuildMember>member.guild?.me,
-					await client.bulbutils.translate("global_mod_action_log", member.guild?.id, {
-						action: await client.bulbutils.translate("mod_action_types.warn", member.guild?.id, {}),
+					member.guild.me,
+					await client.bulbutils.translate("global_mod_action_log", member.guild.id, {
+						action: await client.bulbutils.translate("mod_action_types.warn", member.guild.id, {}),
 						moderator: client.user,
 						target: member.user,
 						reason,
@@ -114,9 +119,9 @@ export default class {
 					client,
 					member.guild.id,
 					member,
-					<GuildMember>member.guild?.me,
-					await client.bulbutils.translate("global_mod_action_log", member.guild?.id, {
-						action: await client.bulbutils.translate("mod_action_types.kick", member.guild?.id, {}),
+					member.guild.me,
+					await client.bulbutils.translate("global_mod_action_log", member.guild.id, {
+						action: await client.bulbutils.translate("mod_action_types.kick", member.guild.id, {}),
 						moderator: client.user,
 						target: member.user,
 						reason,
@@ -127,12 +132,12 @@ export default class {
 			case "BAN":
 				await infractionsManager.ban(
 					client,
-					<Guild>member.guild,
+					member.guild,
 					BanType.CLEAN,
-					<User>member.user,
-					<GuildMember>member.guild?.me,
-					await client.bulbutils.translate("global_mod_action_log", member.guild?.id, {
-						action: await client.bulbutils.translate("mod_action_types.ban", member.guild?.id, {}),
+					member.user,
+					member.guild.me,
+					await client.bulbutils.translate("global_mod_action_log", member.guild.id, {
+						action: await client.bulbutils.translate("mod_action_types.ban", member.guild.id, {}),
 						moderator: client.user,
 						target: member.user,
 						reason,

--- a/src/utils/managers/AutoModManager.ts
+++ b/src/utils/managers/AutoModManager.ts
@@ -86,13 +86,13 @@ export default class {
 	}
 
 	async resolveActionWithoutContext(client: BulbBotClient, member: GuildMember, action: string, reason: string): Promise<string> {
-		if (!member.guild?.id || !member.guild.me) {
+		if (!member.guild.id || !member.guild.me) {
 			client.log.error(`[Auto Mod Manager] Guild is null, reason: ${reason}, target ${member.user.tag} (${member.user.id})`);
 			return "LOG";
 		}
 
 		if (action === null) {
-			client.log.error(`[Auto Mod Manager] Action is null in ${member.guild?.id}, reason: ${reason}, target ${member.user.tag} (${member.user.id})`);
+			client.log.error(`[Auto Mod Manager] Action is null in ${member.guild.id}, reason: ${reason}, target ${member.user.tag} (${member.user.id})`);
 			return "LOG";
 		}
 

--- a/src/utils/managers/ClearanceManager.ts
+++ b/src/utils/managers/ClearanceManager.ts
@@ -58,7 +58,8 @@ export default class {
 		);
 	}
 
-	async getCommandOverride(guildID: Snowflake, name: string): Promise<GuildCommandOverride | undefined> {
+	async getCommandOverride(guildID: Snowflake | undefined, name: string): Promise<GuildCommandOverride | undefined> {
+		if (!guildID) return undefined;
 		const response: GuildCommandOverride[] = await sequelize.query(
 			'SELECT * FROM "guildOverrideCommands" WHERE "commandName" = $CommandName AND "guildId" = (SELECT id FROM guilds WHERE "guildId" = $GuildID)',
 			{

--- a/src/utils/managers/ClearanceManager.ts
+++ b/src/utils/managers/ClearanceManager.ts
@@ -6,7 +6,8 @@ import CommandContext from "src/structures/CommandContext";
 import { GuildCommandOverride, GuildRoleOverride } from "../types/DatabaseStructures";
 
 export default class {
-	async getClearanceList(guildID: Snowflake): Promise<Record<string, any>> {
+	async getClearanceList(guildID: Maybe<Snowflake>): Promise<Record<string, any> | undefined> {
+		if (!guildID) return undefined;
 		const data: Record<string, any> = await sequelize.query('SELECT * FROM "guildOverrideCommands" WHERE "guildId" = (SELECT id FROM guilds WHERE "guildId" = $GuildID)', {
 			bind: { GuildID: guildID },
 			type: QueryTypes.SELECT,
@@ -20,28 +21,32 @@ export default class {
 		return [data, response];
 	}
 
-	async editCommandOverride(guildID: Snowflake, name: string, clearance: number): Promise<void> {
+	async editCommandOverride(guildID: Maybe<Snowflake>, name: string, clearance: number): Promise<void> {
+		if (!guildID) return;
 		await sequelize.query('UPDATE "guildOverrideCommands" SET "clearanceLevel" = $Clearance WHERE "commandName" = $CommandName AND "guildId" = (SELECT id FROM guilds WHERE "guildId" = $GuildID)', {
 			bind: { GuildID: guildID, CommandName: name, Clearance: clearance },
 			type: QueryTypes.UPDATE,
 		});
 	}
 
-	async setEnabled(guildID: Snowflake, name: string, enabled = true): Promise<void> {
+	async setEnabled(guildID: Maybe<Snowflake>, name: string, enabled = true): Promise<void> {
+		if (!guildID) return;
 		await sequelize.query('UPDATE "guildOverrideCommands" SET "enabled" = $Enabled WHERE "commandName" = $CommandName AND "guildId" = (SELECT id FROM guilds WHERE "guildId" = $GuildID)', {
 			bind: { GuildID: guildID, CommandName: name, Enabled: enabled },
 			type: QueryTypes.UPDATE,
 		});
 	}
 
-	async enableCommand(guildID: Snowflake, name: string, enabled: boolean): Promise<void> {
+	async enableCommand(guildID: Maybe<Snowflake>, name: string, enabled: boolean): Promise<void> {
+		if (!guildID) return;
 		await sequelize.query('UPDATE "guildOverrideCommands" SET enabled = $Enabled WHERE "commandName" = $CommandName AND "guildId" = (SELECT id FROM guilds WHERE "guildId" = $GuildID)', {
 			bind: { GuildID: guildID, CommandName: name, Enabled: enabled },
 			type: QueryTypes.UPDATE,
 		});
 	}
 
-	async createCommandOverride(guildID: Snowflake, name: string, enabled = true, clearance: number): Promise<void> {
+	async createCommandOverride(guildID: Maybe<Snowflake>, name: string, enabled = true, clearance: number): Promise<void> {
+		if (!guildID) return;
 		await sequelize.query(
 			'INSERT INTO "guildOverrideCommands" (enabled, "commandName", "clearanceLevel", "createdAt", "updatedAt", "guildId") VALUES ($Enabled, $CommandName, $Clearance, $CreatedAt, $UpdatedAt, (SELECT id FROM guilds WHERE "guildId" = $GuildID))',
 			{
@@ -58,7 +63,7 @@ export default class {
 		);
 	}
 
-	async getCommandOverride(guildID: Snowflake | undefined, name: string): Promise<GuildCommandOverride | undefined> {
+	async getCommandOverride(guildID: Maybe<Snowflake> | undefined, name: string): Promise<GuildCommandOverride | undefined> {
 		if (!guildID) return undefined;
 		const response: GuildCommandOverride[] = await sequelize.query(
 			'SELECT * FROM "guildOverrideCommands" WHERE "commandName" = $CommandName AND "guildId" = (SELECT id FROM guilds WHERE "guildId" = $GuildID)',
@@ -71,14 +76,16 @@ export default class {
 		return response[0];
 	}
 
-	async deleteCommandOverride(guildID: Snowflake, name: string): Promise<void> {
+	async deleteCommandOverride(guildID: Maybe<Snowflake>, name: string): Promise<void> {
+		if (!guildID) return;
 		await sequelize.query('DELETE FROM "guildOverrideCommands" WHERE "commandName" = $CommandName AND "guildId" = (SELECT id FROM guilds WHERE "guildId" = $GuildID)', {
 			bind: { GuildID: guildID, CommandName: name },
 			type: QueryTypes.DELETE,
 		});
 	}
 
-	async createRoleOverride(guildID: Snowflake, roleID: Snowflake, clearance: number): Promise<void> {
+	async createRoleOverride(guildID: Maybe<Snowflake>, roleID: Snowflake, clearance: number): Promise<void> {
+		if (!guildID) return;
 		await sequelize.query(
 			'INSERT INTO "guildModerationRoles" ("roleId", "clearanceLevel", "createdAt", "updatedAt", "guildId") VALUES ($RoleID, $Clearance, $CreatedAt, $UpdatedAt, (SELECT id FROM guilds WHERE "guildId" = $GuildID))',
 			{
@@ -88,7 +95,8 @@ export default class {
 		);
 	}
 
-	async getRoleOverride(guildID: Snowflake, roleID: Snowflake): Promise<GuildRoleOverride | undefined> {
+	async getRoleOverride(guildID: Maybe<Snowflake>, roleID: Snowflake): Promise<GuildRoleOverride | undefined> {
+		if (!guildID) return undefined;
 		const response: GuildRoleOverride[] = await sequelize.query('SELECT * FROM "guildModerationRoles" WHERE "roleId" = $RoleID AND "guildId" = (SELECT id FROM guilds WHERE "guildId" = $GuildID)', {
 			bind: { RoleID: roleID, GuildID: guildID },
 			type: QueryTypes.SELECT,
@@ -97,14 +105,16 @@ export default class {
 		return response[0];
 	}
 
-	async editRoleOverride(guildID: Snowflake, roleID: Snowflake, clearance: number): Promise<void> {
+	async editRoleOverride(guildID: Maybe<Snowflake>, roleID: Snowflake, clearance: number): Promise<void> {
+		if (!guildID) return;
 		await sequelize.query('UPDATE "guildModerationRoles" SET "clearanceLevel" = $Clearance WHERE "roleId" = $RoleID AND "guildId" = (SELECT id FROM guilds WHERE "guildId" = $GuildID)', {
 			bind: { Clearance: clearance, RoleID: roleID, GuildID: guildID },
 			type: QueryTypes.UPDATE,
 		});
 	}
 
-	async deleteRoleOverride(guildID: Snowflake, roleID: Snowflake): Promise<void> {
+	async deleteRoleOverride(guildID: Maybe<Snowflake>, roleID: Snowflake): Promise<void> {
+		if (!guildID) return;
 		await sequelize.query('DELETE FROM "guildModerationRoles" WHERE "roleId" = $RoleID AND "guildId" = (SELECT id FROM guilds WHERE "guildId" = $GuildID)', {
 			bind: { GuildID: guildID, RoleID: roleID },
 			type: QueryTypes.DELETE,

--- a/src/utils/managers/ClearanceManager.ts
+++ b/src/utils/managers/ClearanceManager.ts
@@ -127,7 +127,7 @@ export default class {
 		if (context.member.permissions.has(Permissions.FLAGS.ADMINISTRATOR)) return 75;
 
 		const response: Record<string, any> = await sequelize.query('SELECT * FROM "guildModerationRoles" WHERE "guildId" = (SELECT id FROM guilds WHERE "guildId" = $GuildID)', {
-			bind: { GuildID: context.guild?.id },
+			bind: { GuildID: context.guild.id },
 			type: QueryTypes.SELECT,
 		});
 

--- a/src/utils/managers/DatabaseManager.ts
+++ b/src/utils/managers/DatabaseManager.ts
@@ -315,8 +315,9 @@ export default class {
 			const duplicateSet: Set<string> = new Set();
 			const addedSet: Set<string> = new Set();
 			for (const item of itemSet) {
-				if (dbSet.has(item!)) duplicateSet.add(item!);
-				else dbSet.add(item!), addedSet.add(item!);
+				if (item === undefined) continue;
+				if (dbSet.has(item)) duplicateSet.add(item);
+				else dbSet.add(item), addedSet.add(item);
 			}
 			return { list: [...dbSet], added: [...addedSet], removed: [], other: [...duplicateSet] };
 		});

--- a/src/utils/managers/InfractionsManager.ts
+++ b/src/utils/managers/InfractionsManager.ts
@@ -81,7 +81,9 @@ export default class {
 		);
 	}
 
-	public async isActive(guildID: Snowflake, infractionID: number): Promise<boolean | undefined> {
+	public async isActive(guildID: Snowflake, infractionID: Maybe<number>): Promise<boolean | undefined> {
+		if (typeof infractionID !== "number") return;
+
 		const response: Record<string, any> = await sequelize.query('SELECT active FROM infractions WHERE "guildId" = (SELECT id FROM guilds WHERE "guildId" = $GuildID) AND id = $InfractionID', {
 			bind: { GuildID: guildID, InfractionID: infractionID },
 			type: QueryTypes.SELECT,
@@ -90,7 +92,9 @@ export default class {
 		return JSON.parse(response[0]["active"]);
 	}
 
-	public async setActive(guildID: Snowflake, infractionID: number, active: boolean | number): Promise<void> {
+	public async setActive(guildID: Snowflake, infractionID: Maybe<number>, active: boolean | number): Promise<void> {
+		if (typeof infractionID !== "number") return;
+
 		await sequelize.query('UPDATE infractions SET active = $Active WHERE "guildId" = (SELECT id FROM guilds WHERE "guildId" = $GuildID) AND id = $InfractionID', {
 			bind: { GuildID: guildID, InfractionID: infractionID, Active: active },
 			type: QueryTypes.UPDATE,

--- a/src/utils/managers/InfractionsManager.ts
+++ b/src/utils/managers/InfractionsManager.ts
@@ -198,9 +198,9 @@ export default class {
 	}
 
 	public async tempban(client: BulbBotClient, guild: Guild, target: GuildMember, moderator: GuildMember, reasonLog: string, reason: string, until: MomentInput): Promise<number | null> {
-		if (!target.bannable) return null;
+		if (!target.bannable || (typeof until !== "number" && typeof until !== "boolean")) return null;
 		await target.ban({ reason: reasonLog });
-		await this.createInfraction(guild.id, "Tempban", <number>until, reason, target.user, moderator.user);
+		await this.createInfraction(guild.id, "Tempban", until, reason, target.user, moderator.user);
 		const infID: number = await this.getLatestInfraction(guild.id, moderator.user.id, target.user.id, "Tempban");
 		await loggingManager.sendModActionTemp(client, guild, await client.bulbutils.translate("mod_action_types.temp_ban", guild.id, {}), target.user, moderator.user, reason, infID, until);
 

--- a/src/utils/managers/LoggingManager.ts
+++ b/src/utils/managers/LoggingManager.ts
@@ -97,7 +97,8 @@ export default class {
 		);
 	}
 
-	public async sendCommandLog(client: BulbBotClient, guild: Guild, moderator: User, channelID: Snowflake, command: string): Promise<void> {
+	public async sendCommandLog(client: BulbBotClient, guild: Maybe<Guild>, moderator: User, channelID: Snowflake, command: string): Promise<void> {
+		if (!guild) return;
 		const dbGuild: LoggingConfiguration = await databaseManager.getLoggingConfig(guild.id);
 		const zone: string = client.bulbutils.timezones[await databaseManager.getTimezone(guild.id)];
 		if (!dbGuild || dbGuild.other === null) return;
@@ -115,7 +116,8 @@ export default class {
 		);
 	}
 
-	public async sendEventLog(client: BulbBotClient, guild: Guild, part: LoggingPartString, log: string, extra: string | MessageEmbed[] | null = null): Promise<void> {
+	public async sendEventLog(client: BulbBotClient, guild: Maybe<Guild>, part: LoggingPartString, log: string, extra: string | MessageEmbed[] | null = null): Promise<void> {
+		if (!guild) return;
 		const zone: string = client.bulbutils.timezones[await databaseManager.getTimezone(guild.id)];
 
 		const dbGuild: LoggingConfiguration = await databaseManager.getLoggingConfig(guild.id);
@@ -134,7 +136,8 @@ export default class {
 		});
 	}
 
-	public async sendModActionPreformatted(client: BulbBotClient, guild: Guild, log: string) {
+	public async sendModActionPreformatted(client: BulbBotClient, guild: Maybe<Guild>, log: string) {
+		if (!guild) return;
 		const dbGuild: LoggingConfiguration = await databaseManager.getLoggingConfig(guild.id);
 		const zone: string = client.bulbutils.timezones[await databaseManager.getTimezone(guild.id)];
 

--- a/src/utils/managers/LoggingManager.ts
+++ b/src/utils/managers/LoggingManager.ts
@@ -1,5 +1,5 @@
 import BulbBotClient from "../../structures/BulbBotClient";
-import { Guild, MessageEmbed, NewsChannel, Snowflake, TextChannel, User } from "discord.js";
+import { Channel, FileOptions, Guild, MessageEmbed, NewsChannel, Snowflake, TextChannel, User } from "discord.js";
 import DatabaseManager from "./DatabaseManager";
 import * as Emotes from "../../emotes.json";
 import { defaultPerms } from "../../Config";
@@ -7,6 +7,7 @@ import moment, { MomentInput } from "moment";
 import "moment-timezone";
 import { LoggingPartString } from "../types/LoggingPart";
 import { LoggingConfiguration } from "../types/DatabaseStructures";
+import { isGuildChannel } from "../typechecks";
 
 const databaseManager: DatabaseManager = new DatabaseManager();
 
@@ -17,8 +18,8 @@ export default class {
 
 		if (dbGuild.modAction === null) return;
 
-		const modChannel: TextChannel = <TextChannel>client.channels.cache.get(dbGuild.modAction);
-		if (!modChannel?.guild.me?.permissionsIn(modChannel).has(defaultPerms)) return;
+		const modChannel = client.channels.cache.get(dbGuild.modAction) as Channel;
+		if (!(isGuildChannel(modChannel) && modChannel.isText() && modChannel?.guild.me?.permissionsIn(modChannel).has(defaultPerms))) return;
 
 		await modChannel.send(
 			await client.bulbutils.translate("global_logging_mod", guildID, {
@@ -33,13 +34,14 @@ export default class {
 		);
 	}
 
-	public async sendAutoUnban(client: BulbBotClient, guild: Guild, action: string, target: User, moderator: User, log: string, infID: number): Promise<void> {
+	public async sendAutoUnban(client: BulbBotClient, guild: Maybe<Guild>, action: string, target: User, moderator: User, log: string, infID: number): Promise<void> {
+		if (!guild) return;
 		const dbGuild: LoggingConfiguration = await databaseManager.getLoggingConfig(guild.id);
 		const zone: string = client.bulbutils.timezones[await databaseManager.getTimezone(guild.id)];
 		if (dbGuild.modAction === null) return;
 
-		const modChannel: TextChannel = <TextChannel>client.channels.cache.get(dbGuild.modAction);
-		if (!modChannel?.guild.me?.permissionsIn(modChannel).has(defaultPerms)) return;
+		const modChannel = client.channels.cache.get(dbGuild.modAction) as Channel;
+		if (!(isGuildChannel(modChannel) && modChannel.isText() && modChannel?.guild.me?.permissionsIn(modChannel).has(defaultPerms))) return;
 
 		await modChannel.send(
 			await client.bulbutils.translate("global_logging_mod_unban_auto", guild.id, {
@@ -54,13 +56,15 @@ export default class {
 		);
 	}
 
-	public async sendModActionFile(client: BulbBotClient, guild: Guild, action, amount, file, channel, moderator) {
+	// TODO: This is tightly coupled to the purge command, ideally it wouldn't need to be (or else would be named different)
+	public async sendModActionFile(client: BulbBotClient, guild: Maybe<Guild>, action: string, amount: number, file: FileOptions["attachment"], channel: Channel, moderator: User): Promise<void> {
+		if (!guild) return;
 		const dbGuild: LoggingConfiguration = await databaseManager.getLoggingConfig(guild.id);
 		const zone: string = client.bulbutils.timezones[await databaseManager.getTimezone(guild.id)];
 		if (dbGuild.modAction === null) return;
 
-		const modChannel: TextChannel = <TextChannel>client.channels.cache.get(dbGuild.modAction);
-		if (!modChannel?.guild.me?.permissionsIn(modChannel).has(defaultPerms)) return;
+		const modChannel = client.channels.cache.get(dbGuild.modAction) as Channel;
+		if (!(isGuildChannel(modChannel) && modChannel.isText() && modChannel?.guild.me?.permissionsIn(modChannel).has(defaultPerms))) return;
 
 		await modChannel.send({
 			content: `\`[${moment().tz(zone).format("hh:mm:ssa z")}]\` ${await this.betterActions(client, guild.id, "trash")} **${moderator.tag}** \`(${
@@ -75,13 +79,14 @@ export default class {
 		});
 	}
 
-	public async sendModActionTemp(client: BulbBotClient, guild: Guild, action: string, target: User, moderator: User, log: string, infID: number, until: MomentInput): Promise<void> {
+	public async sendModActionTemp(client: BulbBotClient, guild: Maybe<Guild>, action: string, target: User, moderator: User, log: string, infID: number, until: MomentInput): Promise<void> {
+		if (!guild) return;
 		const dbGuild: LoggingConfiguration = await databaseManager.getLoggingConfig(guild.id);
 		const zone: string = client.bulbutils.timezones[await databaseManager.getTimezone(guild.id)];
 		if (dbGuild.modAction === null) return;
 
-		const modChannel: TextChannel = <TextChannel>client.channels.cache.get(dbGuild.modAction);
-		if (!modChannel?.guild.me?.permissionsIn(modChannel).has(defaultPerms)) return;
+		const modChannel = client.channels.cache.get(dbGuild.modAction) as Channel;
+		if (!(isGuildChannel(modChannel) && modChannel.isText() && modChannel?.guild.me?.permissionsIn(modChannel).has(defaultPerms))) return;
 
 		await modChannel.send(
 			await client.bulbutils.translate("global_logging_mod_temp", guild.id, {
@@ -103,8 +108,8 @@ export default class {
 		const zone: string = client.bulbutils.timezones[await databaseManager.getTimezone(guild.id)];
 		if (!dbGuild || dbGuild.other === null) return;
 
-		const modChannel: TextChannel = <TextChannel>client.channels.cache.get(dbGuild.other);
-		if (!modChannel?.guild.me?.permissionsIn(modChannel).has(defaultPerms)) return;
+		const modChannel = client.channels.cache.get(dbGuild.other) as Channel;
+		if (!(isGuildChannel(modChannel) && modChannel.isText() && modChannel?.guild.me?.permissionsIn(modChannel).has(defaultPerms))) return;
 
 		await modChannel.send(
 			await client.bulbutils.translate("global_logging_command", guild.id, {
@@ -117,6 +122,8 @@ export default class {
 	}
 
 	public async sendEventLog(client: BulbBotClient, guild: Maybe<Guild>, part: LoggingPartString, log: string, extra: string | MessageEmbed[] | null = null): Promise<void> {
+		// Really, we should probably be narrowing these types at the CommandContext level or something, e.g. we know in our usage that we don't
+		// operate with DM commands so we already will have returned unless `guild`, `me`, etc. are defined
 		if (!guild) return;
 		const zone: string = client.bulbutils.timezones[await databaseManager.getTimezone(guild.id)];
 
@@ -143,20 +150,22 @@ export default class {
 
 		if (dbGuild.modAction === null) return;
 
-		const modChannel: TextChannel = <TextChannel>client.channels.cache.get(dbGuild.modAction);
-		if (!modChannel?.guild.me?.permissionsIn(modChannel).has(defaultPerms)) return;
+		const modChannel = client.channels.cache.get(dbGuild.modAction) as Channel;
+		if (!(isGuildChannel(modChannel) && modChannel.isText() && modChannel?.guild.me?.permissionsIn(modChannel).has(defaultPerms))) return;
 
 		await modChannel.send(`\`[${moment().tz(zone).format("hh:mm:ssa z")}]\` ${log}`);
 	}
 
-	public async sendAutoModLog(client: BulbBotClient, guild: Guild, log: string, buffer?: Buffer) {
+	public async sendAutoModLog(client: BulbBotClient, guild: Maybe<Guild>, log: string, buffer?: Buffer) {
+		if (!guild) return;
 		const dbGuild: LoggingConfiguration = await databaseManager.getLoggingConfig(guild.id);
 		const zone: string = client.bulbutils.timezones[await databaseManager.getTimezone(guild.id)];
 
 		if (dbGuild.automod === null) return;
 
-		const modChannel: TextChannel = <TextChannel>client.channels.cache.get(dbGuild.automod);
-		if (!modChannel?.guild.me?.permissionsIn(modChannel).has(defaultPerms)) return;
+		const modChannel = client.channels.cache.get(dbGuild.automod) as Channel;
+		if (!(isGuildChannel(modChannel) && modChannel.isText() && modChannel?.guild.me?.permissionsIn(modChannel).has(defaultPerms))) return;
+
 		let files: any = null;
 
 		if (buffer)
@@ -173,7 +182,7 @@ export default class {
 		});
 	}
 
-	private async betterActions(client: BulbBotClient, guildID: Snowflake, action: string): Promise<string> {
+	private async betterActions(client: BulbBotClient, guildID: Maybe<Snowflake>, action: string): Promise<string> {
 		switch (action) {
 			case await client.bulbutils.translate("mod_action_types.pool_ban", guildID, {}):
 			case await client.bulbutils.translate("mod_action_types.soft_ban", guildID, {}):

--- a/src/utils/managers/LoggingManager.ts
+++ b/src/utils/managers/LoggingManager.ts
@@ -19,7 +19,7 @@ export default class {
 		if (dbGuild.modAction === null) return;
 
 		const modChannel = client.channels.cache.get(dbGuild.modAction) as Channel;
-		if (!(isGuildChannel(modChannel) && modChannel.isText() && modChannel?.guild.me?.permissionsIn(modChannel).has(defaultPerms))) return;
+		if (!(isGuildChannel(modChannel) && modChannel.isText() && modChannel.guild.me?.permissionsIn(modChannel).has(defaultPerms))) return;
 
 		await modChannel.send(
 			await client.bulbutils.translate("global_logging_mod", guildID, {
@@ -41,7 +41,7 @@ export default class {
 		if (dbGuild.modAction === null) return;
 
 		const modChannel = client.channels.cache.get(dbGuild.modAction) as Channel;
-		if (!(isGuildChannel(modChannel) && modChannel.isText() && modChannel?.guild.me?.permissionsIn(modChannel).has(defaultPerms))) return;
+		if (!(isGuildChannel(modChannel) && modChannel.isText() && modChannel.guild.me?.permissionsIn(modChannel).has(defaultPerms))) return;
 
 		await modChannel.send(
 			await client.bulbutils.translate("global_logging_mod_unban_auto", guild.id, {
@@ -64,7 +64,7 @@ export default class {
 		if (dbGuild.modAction === null) return;
 
 		const modChannel = client.channels.cache.get(dbGuild.modAction) as Channel;
-		if (!(isGuildChannel(modChannel) && modChannel.isText() && modChannel?.guild.me?.permissionsIn(modChannel).has(defaultPerms))) return;
+		if (!(isGuildChannel(modChannel) && modChannel.isText() && modChannel.guild.me?.permissionsIn(modChannel).has(defaultPerms))) return;
 
 		await modChannel.send({
 			content: `\`[${moment().tz(zone).format("hh:mm:ssa z")}]\` ${await this.betterActions(client, guild.id, "trash")} **${moderator.tag}** \`(${
@@ -86,7 +86,7 @@ export default class {
 		if (dbGuild.modAction === null) return;
 
 		const modChannel = client.channels.cache.get(dbGuild.modAction) as Channel;
-		if (!(isGuildChannel(modChannel) && modChannel.isText() && modChannel?.guild.me?.permissionsIn(modChannel).has(defaultPerms))) return;
+		if (!(isGuildChannel(modChannel) && modChannel.isText() && modChannel.guild.me?.permissionsIn(modChannel).has(defaultPerms))) return;
 
 		await modChannel.send(
 			await client.bulbutils.translate("global_logging_mod_temp", guild.id, {
@@ -109,7 +109,7 @@ export default class {
 		if (!dbGuild || dbGuild.other === null) return;
 
 		const modChannel = client.channels.cache.get(dbGuild.other) as Channel;
-		if (!(isGuildChannel(modChannel) && modChannel.isText() && modChannel?.guild.me?.permissionsIn(modChannel).has(defaultPerms))) return;
+		if (!(isGuildChannel(modChannel) && modChannel.isText() && modChannel.guild.me?.permissionsIn(modChannel).has(defaultPerms))) return;
 
 		await modChannel.send(
 			await client.bulbutils.translate("global_logging_command", guild.id, {
@@ -151,7 +151,7 @@ export default class {
 		if (dbGuild.modAction === null) return;
 
 		const modChannel = client.channels.cache.get(dbGuild.modAction) as Channel;
-		if (!(isGuildChannel(modChannel) && modChannel.isText() && modChannel?.guild.me?.permissionsIn(modChannel).has(defaultPerms))) return;
+		if (!(isGuildChannel(modChannel) && modChannel.isText() && modChannel.guild.me?.permissionsIn(modChannel).has(defaultPerms))) return;
 
 		await modChannel.send(`\`[${moment().tz(zone).format("hh:mm:ssa z")}]\` ${log}`);
 	}
@@ -164,7 +164,7 @@ export default class {
 		if (dbGuild.automod === null) return;
 
 		const modChannel = client.channels.cache.get(dbGuild.automod) as Channel;
-		if (!(isGuildChannel(modChannel) && modChannel.isText() && modChannel?.guild.me?.permissionsIn(modChannel).has(defaultPerms))) return;
+		if (!(isGuildChannel(modChannel) && modChannel.isText() && modChannel.guild.me?.permissionsIn(modChannel).has(defaultPerms))) return;
 
 		let files: any = null;
 

--- a/src/utils/typechecks.ts
+++ b/src/utils/typechecks.ts
@@ -1,5 +1,9 @@
-import { BaseGuildTextChannel, Channel } from "discord.js";
+import { BaseGuildTextChannel, Channel, TextChannel } from "discord.js";
 
 export function isBaseGuildTextChannel(channel: Maybe<Channel>): channel is BaseGuildTextChannel {
 	return !!channel && "defaultAutoArchiveDuration" in channel;
+}
+
+export function isTextChannel(channel: Maybe<Channel>): channel is TextChannel {
+	return !!channel && "rateLimitPerUser" in channel;
 }

--- a/src/utils/typechecks.ts
+++ b/src/utils/typechecks.ts
@@ -1,4 +1,4 @@
-import { BaseGuildTextChannel, Channel, TextChannel } from "discord.js";
+import { AnyChannel, BaseGuildTextChannel, Channel, GuildBasedChannel, TextChannel } from "discord.js";
 
 export function isBaseGuildTextChannel(channel: Maybe<Channel>): channel is BaseGuildTextChannel {
 	return !!channel && "defaultAutoArchiveDuration" in channel;
@@ -6,4 +6,10 @@ export function isBaseGuildTextChannel(channel: Maybe<Channel>): channel is Base
 
 export function isTextChannel(channel: Maybe<Channel>): channel is TextChannel {
 	return !!channel && "rateLimitPerUser" in channel;
+}
+
+export function isGuildChannel(channel: Maybe<Channel>): channel is GuildBasedChannel;
+export function isGuildChannel(channel: Maybe<AnyChannel>): channel is GuildBasedChannel;
+export function isGuildChannel(channel: Maybe<any>): channel is GuildBasedChannel {
+	return !!channel && "guild" in channel;
 }

--- a/src/utils/types/ResolveCommandOptions.ts
+++ b/src/utils/types/ResolveCommandOptions.ts
@@ -26,7 +26,7 @@ export default class ResolveCommandOptions {
 	static async create(command: Command, context: CommandContext, args: string[], options: ResolveCommandOptionsOptions = {}): Promise<ResolveCommandOptions> {
 		const instance = new ResolveCommandOptions(command, context, args, options);
 		instance.clearance = await clearanceManager.getUserClearance(context);
-		instance.premiumGuild = (await databaseManager.getConfig(context.guild!.id)).premiumGuild;
+		instance.premiumGuild = !!context.guild?.id && (await databaseManager.getConfig(context.guild.id)).premiumGuild;
 		return instance;
 	}
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -14,3 +14,7 @@ type Optional<T> = T | undefined;
 type Maybe<T> = T | null | undefined;
 /** Inverse of TypeScript built-in utility type `Exclude<T, U>` */
 type Include<T, U> = T extends U ? T : never;
+/** Generic interface for anything with an id field. Can be used for mixins, type annotations, etc. */
+interface Identifiable {
+	id: string;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -591,6 +591,11 @@
   resolved "https://registry.npmjs.org/@types/node/-/node-17.0.4.tgz"
   integrity sha512-6xwbrW4JJiJLgF+zNypN5wr2ykM9/jHcL7rQ8fZe2vuftggjzZeRSM4OwRc6Xk8qWjwJ99qVHo/JgOGmomWRog==
 
+"@types/node@^17.0.23":
+  version "17.0.23"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.23.tgz#3b41a6e643589ac6442bdbd7a4a3ded62f33f7da"
+  integrity sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==
+
 "@types/sharp@^0.29.5":
   version "0.29.5"
   resolved "https://registry.npmjs.org/@types/sharp/-/sharp-0.29.5.tgz"


### PR DESCRIPTION
This PR is an extension of the `dev/eslint` branch. This branch includes changes that remove (nearly) all non-null assertions, and (nearly) all type assertions being used to hide null/undefined. These changes require actually checking types in order to narrow them, so it's more possible for these changes to have inadvertent regressions.

This branch could be merged into `dev/eslint`, but could also be held and merged later, so that it can be tested more. This would allow `dev/eslint` to merge sooner.