### PR TITLE
bug: fixes the mute bug 348

### DIFF
--- a/src/commands/Moderation/mute.ts
+++ b/src/commands/Moderation/mute.ts
@@ -49,7 +49,8 @@ export default class extends Command {
 		if (!reason) reason = await this.client.bulbutils.translate("global_no_reason", context.guild?.id, {});
 		if ((duration && duration <= <number>parse("0s")) || duration === null) return context.channel.send(await this.client.bulbutils.translate("duration_invalid_0s", context.guild?.id, {}));
 		if (duration > <number>parse("28d")) return context.channel.send(await this.client.bulbutils.translate("duration_invalid_28d", context.guild?.id, {}));
-		if (target.communicationDisabledUntilTimestamp !== null) return context.channel.send(await this.client.bulbutils.translate("mute_already_muted", context.guild?.id, { target: target.user }));
+		if (target.communicationDisabledUntilTimestamp !== null && Date.now() < target.communicationDisabledUntilTimestamp!)
+			return context.channel.send(await this.client.bulbutils.translate("mute_already_muted", context.guild?.id, { target: target.user }));
 
 		const infID = await infractionsManager.mute(
 			this.client,


### PR DESCRIPTION
This fix fixes the bug #348 by checking if the timestmap of the last change of communication is smaller then the current timestamp

```js
if (target.communicationDisabledUntilTimestamp !== null && Date.now() < target.communicationDisabledUntilTimestamp!)
			return context.channel.send(await this.client.bulbutils.translate("mute_already_muted", context.guild?.id, { target: target.user }));
```
