### PR TITLE
feat: made the manuel infractions a toggle

### DIFF
--- a/src/commands/Configuration/configure.ts
+++ b/src/commands/Configuration/configure.ts
@@ -76,6 +76,12 @@ export default class extends Command {
 						emoji: Emotes.features.HUB,
 					},
 					{
+						label: await this.client.bulbutils.translate("config_main_options.manuel_nickname_inf", context.guild?.id, {}),
+						value: "manuelNicknameInf",
+						description: await this.client.bulbutils.translate("config_main_options_descriptions.manuel_nickname_inf", context.guild?.id, {}),
+						emoji: Emotes.features.MEMBER_LIST_DISABLED,
+					},
+					{
 						label: await this.client.bulbutils.translate("config_main_options.timezone", context.guild?.id, {}),
 						value: "timezone",
 						description: await this.client.bulbutils.translate("config_main_options_descriptions.timezone", context.guild?.id, {}),

--- a/src/commands/Configuration/configure/main.ts
+++ b/src/commands/Configuration/configure/main.ts
@@ -59,6 +59,12 @@ export default async function (interaction: MessageComponentInteraction, client:
 					emoji: Emotes.features.HUB,
 				},
 				{
+					label: await client.bulbutils.translate("config_main_options.manuel_nickname_inf", interaction.guild?.id, {}),
+					value: "manuelNicknameInf",
+					description: await client.bulbutils.translate("config_main_options_descriptions.manuel_nickname_inf", interaction.guild?.id, {}),
+					emoji: Emotes.features.MEMBER_LIST_DISABLED,
+				},
+				{
 					label: await client.bulbutils.translate("config_main_options.timezone", interaction.guild?.id, {}),
 					value: "timezone",
 					description: await client.bulbutils.translate("config_main_options_descriptions.timezone", interaction.guild?.id, {}),

--- a/src/commands/Configuration/configure/manuelNicknameInf.ts
+++ b/src/commands/Configuration/configure/manuelNicknameInf.ts
@@ -1,0 +1,68 @@
+import { MessageActionRow, MessageButton, MessageComponentInteraction, MessageSelectMenu, Snowflake } from "discord.js";
+import DatabaseManager from "../../../utils/managers/DatabaseManager";
+import { GuildConfiguration } from "../../../utils/types/DatabaseStructures";
+import BulbBotClient from "../../../structures/BulbBotClient";
+
+const { getConfig, setManuelNicknameInf } = new DatabaseManager();
+
+async function manuelNicknameInf(interaction: MessageComponentInteraction, client: BulbBotClient) {
+	const config: GuildConfiguration = await getConfig(interaction.guild?.id as Snowflake);
+
+	const selectRow = new MessageActionRow().addComponents(
+		new MessageSelectMenu()
+			.setCustomId("placeholder")
+			.setPlaceholder(`Currently ${config.manuelNicknameInf ? "enabled" : "disabled"}`)
+			.setDisabled(true)
+			.addOptions([
+				{
+					label: "Placeholder",
+					value: "placeholder",
+				},
+			]),
+	);
+
+	const [enable, disable, back] = [
+		await client.bulbutils.translate("config_button_enable", interaction.guild?.id, {}),
+		await client.bulbutils.translate("config_button_disable", interaction.guild?.id, {}),
+		await client.bulbutils.translate("config_button_back", interaction.guild?.id, {}),
+	];
+
+	const buttonRow = new MessageActionRow().addComponents([
+		new MessageButton().setCustomId("back").setStyle("DANGER").setLabel(back),
+		new MessageButton()
+			.setCustomId(config.manuelNicknameInf ? "disable" : "enable")
+			.setStyle(config.manuelNicknameInf ? "DANGER" : "SUCCESS")
+			.setLabel(config.manuelNicknameInf ? disable : enable),
+	]);
+
+	await interaction.update({
+		content: await client.bulbutils.translate("config_manuel_nickname_infractions", interaction.guild?.id, {}),
+		components: [selectRow, buttonRow],
+	});
+
+	const filter = (i: MessageComponentInteraction) => i.user.id === interaction.user.id;
+	const collector = interaction.channel?.createMessageComponentCollector({ filter, time: 60000, max: 1 });
+
+	collector?.on("collect", async (i: MessageComponentInteraction) => {
+		if (i.isButton()) {
+			switch (i.customId) {
+				case "back":
+					await require("./main").default(i, client);
+					break;
+				case "enable":
+					await setManuelNicknameInf(i.guild?.id as Snowflake, true);
+					await manuelNicknameInf(i, client);
+					break;
+				case "disable":
+					await setManuelNicknameInf(i.guild?.id as Snowflake, false);
+					await manuelNicknameInf(i, client);
+					break;
+				default:
+					await require("./main").default(i, client);
+					break;
+			}
+		}
+	});
+}
+
+export default manuelNicknameInf;

--- a/src/commands/Configuration/settings.ts
+++ b/src/commands/Configuration/settings.ts
@@ -37,6 +37,7 @@ export default class extends Command {
 			`Auto Role:  ${guildConfig.autorole !== null ? `<@&${guildConfig.autorole}>` : Emotes.other.SWITCHOFF}`,
 			`Actions on Info:  ${guildConfig.actionsOnInfo ? Emotes.other.SWITCHON : Emotes.other.SWITCHOFF}`,
 			`Roles on Leave:  ${guildConfig.rolesOnLeave ? Emotes.other.SWITCHON : Emotes.other.SWITCHOFF}`,
+			`Nickname change infraction:  ${guildConfig.manuelNicknameInf ? Emotes.other.SWITCHON : Emotes.other.SWITCHOFF}`,
 			`Quick reasons: ${guildConfig.quickReasons.length ? guildConfig.quickReasons.map((r) => `\`${r}\``).join(" ") : Emotes.other.SWITCHOFF}`,
 		];
 

--- a/src/events/guild/member/guildMemberUpdate.ts
+++ b/src/events/guild/member/guildMemberUpdate.ts
@@ -109,7 +109,12 @@ export default class extends Event {
 		switch (change) {
 			case "nickname":
 				part = "member";
-				if (auditLog?.changes && auditLog.changes[0].key === "nick") {
+				if (!auditLog) {
+					audit = await newMember.guild.fetchAuditLogs({ limit: 1, type: "MEMBER_UPDATE" });
+					auditLog = audit.entries.first();
+				}
+
+				if (auditLog?.changes && auditLog.changes[0].key === "nick" && (await databaseManager.getConfig(newMember.guild.id)).manuelNicknameInf) {
 					executor = auditLog.executor;
 					if (!executor?.id || executor.id === this.client.user?.id) return;
 

--- a/src/languages/en-US.json
+++ b/src/languages/en-US.json
@@ -129,6 +129,7 @@
 	"config_main_options": {
 		"language": "Language",
 		"actions_on_info": "Actions on Info",
+		"manuel_nickname_inf": "Manuel nickname infractions",
 		"prefix": "Prefix",
 		"roles_on_leave": "Roles on Leave",
 		"automod": "Automod",
@@ -140,6 +141,7 @@
 	"config_main_options_descriptions": {
 		"language": "Change the language of the bot",
 		"actions_on_info": "Configure the actions on info setting",
+		"manuel_nickname_inf": "Changing a users nickname results in a infraction",
 		"prefix": "Configure the prefix of the bot",
 		"roles_on_leave": "Configure the roles on leave setting",
 		"automod": "Configure the Automod settings",
@@ -151,6 +153,7 @@
 	"config_main_placeholder": "Select a category to modify",
 	"config_actions_on_info_header": "{{emote_wrench}} **Actions on Info Configuration**\n{{emote_edit}}*This setting controls whether or not action buttons will be displayed when you info a user.*",
 	"config_roles_on_leave_header": "{{emote_wrench}} **Roles on Leave Configuration**\n{{emote_edit}}*This setting controls whether or not the bot will log user's roles when they leave the server.*",
+	"config_manuel_nickname_infractions": "{{emote_wrench}} **Manuel nickname infractions Configuration**\n{{emote_edit}}*This settings controls wheter or not the bot will track infractions on users when a mod gives them an nickname*",
 	"config_language_header": "{{emote_wrench}} **Language Configuration**\n{{emote_edit}}*This setting controls the language that the bot will use when responding to commands.*",
 	"config_language_placeholder": "Select a language",
 	"config_language_success": "{{emote_success}} Successfully changed the server language to `{{language}}`",

--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -175,6 +175,7 @@ export default {
 	config_main_options: {
 		language: "Language",
 		actions_on_info: "Actions on Info",
+		manuel_nickname_inf: "Manuel nickname infractions",
 		prefix: "Prefix",
 		roles_on_leave: "Roles on Leave",
 		automod: "Automod",
@@ -186,6 +187,7 @@ export default {
 	config_main_options_descriptions: {
 		language: "Change the language of the bot",
 		actions_on_info: "Configure the actions on info setting",
+		manuel_nickname_inf: "Changing a users nickname results in a infraction",
 		prefix: "Configure the prefix of the bot",
 		roles_on_leave: "Configure the roles on leave setting",
 		automod: "Configure the Automod settings",
@@ -198,6 +200,8 @@ export default {
 
 	config_actions_on_info_header: "{{emote_wrench}} **Actions on Info Configuration**\n{{emote_edit}}*This setting controls whether or not action buttons will be displayed when you info a user.*",
 	config_roles_on_leave_header: "{{emote_wrench}} **Roles on Leave Configuration**\n{{emote_edit}}*This setting controls whether or not the bot will log user's roles when they leave the server.*",
+	config_manuel_nickname_infractions:
+		"{{emote_wrench}} **Manuel nickname infractions Configuration**\n{{emote_edit}}*This settings controls wheter or not the bot will track infractions on users when a mod gives them an nickname*",
 
 	config_language_header: "{{emote_wrench}} **Language Configuration**\n{{emote_edit}}*This setting controls the language that the bot will use when responding to commands.*",
 	config_language_placeholder: "Select a language",

--- a/src/utils/database/models/GuildConfiguration.ts
+++ b/src/utils/database/models/GuildConfiguration.ts
@@ -33,6 +33,10 @@ export default function (sequelize: Sequelize): void {
 			type: DataTypes.BOOLEAN,
 			defaultValue: false,
 		},
+		manuelNicknameInf: {
+			type: DataTypes.BOOLEAN,
+			defaultValue: false,
+		},
 		quickReasons: {
 			type: DataTypes.ARRAY(DataTypes.STRING),
 			defaultValue: ["Spam", "Swearing", "Toxic behavior", "Advertising"],

--- a/src/utils/managers/DatabaseManager.ts
+++ b/src/utils/managers/DatabaseManager.ts
@@ -140,6 +140,13 @@ export default class {
 		});
 	}
 
+	async setManuelNicknameInf(guildID: Snowflake, enabled: boolean): Promise<void> {
+		await sequelize.query('UPDATE "guildConfigurations" SET "manuelNicknameInf" = $Enabled WHERE id = (SELECT "guildConfigurationId" FROM guilds WHERE "guildId" = $GuildID)', {
+			bind: { GuildID: guildID, Enabled: enabled },
+			type: QueryTypes.UPDATE,
+		});
+	}
+
 	async setPremium(guildID: Snowflake, premium: boolean): Promise<void> {
 		await sequelize.query('UPDATE "guildConfigurations" SET "premiumGuild" = $Premium WHERE id = (SELECT "guildConfigurationId" FROM guilds WHERE "guildId" = $GuildID)', {
 			bind: { Premium: premium, GuildID: guildID },

--- a/src/utils/types/DatabaseStructures.ts
+++ b/src/utils/types/DatabaseStructures.ts
@@ -9,6 +9,7 @@ export interface GuildConfiguration {
 	autorole: Snowflake;
 	actionsOnInfo: boolean;
 	rolesOnLeave: boolean;
+	manuelNicknameInf: boolean;
 	quickReasons: string[];
 }
 


### PR DESCRIPTION
This decision was made for a couple of reasons. Mostly bececause mods got confused as to why some of their users had infractions on them as this was not made clear when adding the bot so we decided to make this a toggle. Some stats on this, this is the largest part of infraction list sorted by the as seen by this graph.
![](https://cdn.discordapp.com/attachments/928757369767354369/970661615332655204/OWtGmAoPOoXJUUp.png)
![](https://cdn.discordapp.com/attachments/928757369767354369/970661967742267392/gEZ3X4asdwghZAm.png)

With this change will we also nuke all previous infractions related to this as to avoid any further confusion regarding the feature.