### PR TITLE
Misc util stuff

### DIFF
--- a/src/utils/BulbBotUtils.ts
+++ b/src/utils/BulbBotUtils.ts
@@ -204,6 +204,7 @@ export default class {
 		return user;
 	}
 
+	/** Consider deprecating */
 	public prettify(action: string): string {
 		return (
 			{

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,3 +1,5 @@
+import * as Emotes from "../emotes.json";
+
 // Miscellaneous helper functions & idioms
 // So they don't need to be referenced from bulbutils
 
@@ -15,4 +17,38 @@ export function tryIgnore<T extends (...args: any[]) => any>(cb: T, ...args: Par
 
 export function clone<T extends object | null>(obj: T): T {
 	return Object.assign(Object.create(obj), obj);
+}
+
+export function interpolateArrays<T extends any[]>(...args: T[]): T {
+	if (args.length < 2) return args[0];
+	const lengths = args.map((arr) => arr.length);
+	const longestLength = Math.max(...lengths);
+	const interpolated: any[] = [];
+	for (let i = 0; i < longestLength; ++i) {
+		for (let j = 0; j < args.length; ++j) {
+			const arr = args[j];
+			if (arr.length <= i) continue;
+			interpolated.push(arr[i]);
+		}
+	}
+	return interpolated as T;
+}
+
+export function emote(strings: TemplateStringsArray, ...actions: string[]): string {
+	const emoteResolver: Record<string, string> = {
+		Ban: Emotes.actions.BAN,
+		"Manual Ban": Emotes.actions.BAN,
+		"Force-ban": Emotes.actions.BAN,
+		Kick: Emotes.actions.KICK,
+		"Manual Kick": Emotes.actions.KICK,
+		Mute: Emotes.actions.MUTE,
+		Warn: Emotes.actions.WARN,
+		Unmute: Emotes.actions.UNBAN,
+		Unban: Emotes.actions.UNBAN,
+		true: Emotes.status.ONLINE,
+		false: Emotes.other.INF1,
+		Nickname: Emotes.other.EDIT,
+	};
+	const resolveEmotes = actions.map((action) => emoteResolver[action] || action);
+	return interpolateArrays([...strings], resolveEmotes).join(" ");
 }


### PR DESCRIPTION
- Rewrote the supported languages util to be better in every way. Do we still use that? Do we need to add any languages to it? Looked like there were fewer languages there than we have language files for.
- Added a [tagged template literal](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates) based on the `prettify` method in BulbUtils. Essentially, this is the same thing except the result is free-form, instead of just "(emote) action". Example, you could write
```ts
const result = emote`${'Kick'} Some user has been kicked from the server`;
```
And it would return the same string, but with the actual `KICK` emoji interpolated where it says `${'Kick'}`. And this can of course be used with arbitrary variables, not just hardcoded strings. This was kinda just an experiment, I don't know if it'll be actually useful for us in practice, but I think it's neat.

I cut this branch from `fix/nodemon` because I wanted to use nodemon while developing. The base for this PR will automatically change to master if/when that branch merges