### PR TITLE
Avoid splitting the nickname argument passed in slash command

### DIFF
--- a/src/commands/Moderation/nickname.ts
+++ b/src/commands/Moderation/nickname.ts
@@ -43,7 +43,8 @@ export default class extends Command {
 		const nickname: string = (nickmatch ? nickmatch[1] : args[1]).trim() ?? "";
 		const reason: string =
 			args
-				.slice(1 + nickname.split(" ").length)
+				// Interaction commands will pass multi-word nicknames as a single argument (unless it is quoted, in which case it'll split the argument)
+				.slice(1 + (nickmatch ? nickname.split(" ").length : 1))
 				.join(" ")
 				.trim() || (await this.client.bulbutils.translate("global_no_reason", context.guild?.id, {}));
 		if (!target)

--- a/src/events/bot/interactionCreate.ts
+++ b/src/events/bot/interactionCreate.ts
@@ -90,6 +90,16 @@ export default class extends Event {
 			}
 
 			let used = `/${command.qualifiedName}`;
+			if (command.name === "nickname") {
+				// This fix is temporary, until we remove the text-commands
+				// TODO(@wakfi): Move this into the nickname handler directly, once we officially drop text-based commands
+				args.splice(0, args.length);
+				const member = context.options.getUser("member", true);
+				const nickname = context.options.getString("nickname") ?? "";
+				const reason = context.options.getString("reason") ?? "";
+				// Pass in the arguments without splitting, to behave nicely with the text parsing done in the nickname command
+				args.push(`${member}`, ...(nickname.startsWith('"') && nickname.endsWith('"') ? `${nickname}`.split(" ") : [`${nickname}`]), ...`${reason}`.split(" "));
+			}
 			args.forEach((arg) => (used += ` ${arg}`));
 			await loggingManager.sendCommandLog(this.client, interaction.guild, context.author, context.channel.id, used);
 


### PR DESCRIPTION
Since there's no ambiguity due to the slash command system having argument labling built-in, we don't need to try to figure out what to use as nickname and what to pass on to the reason, it just tells us which is the nickname. We can pass the nickname from the interaction in as a single string without splitting it in order to 'trick' the command handler into using it fully

Resolves #335 