### PR TITLE
Change some DB types

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -3,4 +3,5 @@ module.exports = {
 	'*.{js,ts,md}': 'prettier --write',
 	'*.ts': () => 'yarn typecheck',
 	'*.{js,ts}': 'yarn eslint',
+	'*.prisma': () => 'yarn prisma format',
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"prepare": "yarn husky install && yarn generate",
 		"generate": "prisma generate",
 		"db:migrate": "prisma migrate dev",
-		"db:migrate:prod": "prisma migrate",
+		"db:deploy": "prisma migrate deploy",
 		"db:nuke": "prisma migrate reset",
 		"db:introspect": "prisma db pull",
 		"db:push": "prisma db push",

--- a/src/commands/Moderation/infraction/info.ts
+++ b/src/commands/Moderation/infraction/info.ts
@@ -59,17 +59,14 @@ export default class extends SubCommand {
 			created: moment(inf.createdAt).format("MMM Do YYYY, h:mm:ss a"),
 		});
 
-		if (inf.active !== "false" && inf.active !== "true") {
+		if (inf.timeout) {
 			description += await this.client.bulbutils.translate("infraction_info_expires", context.guild.id, {
-				expires: `${Emotes.status.ONLINE} ${moment(parseInt(inf.active)).format("MMM Do YYYY, h:mm:ss a")}`,
-			});
-		} else {
-			description += await this.client.bulbutils.translate("infraction_info_active", context.guild.id, {
-				active: this.client.bulbutils.prettify(inf.active),
+				expires: `${Emotes.status.ONLINE} ${moment(parseInt(inf.timeout)).format("MMM Do YYYY, h:mm:ss a")}`,
 			});
 		}
-
 		description += await this.client.bulbutils.translate("infraction_info_reason", context.guild.id, { reason: inf.reason });
+
+		description += await this.client.bulbutils.translate("infraction_info_active", context.guild.id, { active: this.client.bulbutils.prettify(`${inf.active}`) });
 
 		const image = inf.reason.match(ReasonImage);
 

--- a/src/events/guild/member/guildMemberUpdate.ts
+++ b/src/events/guild/member/guildMemberUpdate.ts
@@ -63,10 +63,11 @@ export default class extends Event {
 				const { id: infID } = await infractionsManager.createInfraction(
 					newMember.guild.id,
 					"Mute",
-					newMember.communicationDisabledUntilTimestamp,
+					true,
 					auditLog?.reason ? auditLog.reason : await this.client.bulbutils.translate("global_no_reason", newMember.guild.id, {}),
 					newMember.user,
 					executor,
+					newMember.communicationDisabledUntilTimestamp,
 				);
 				await loggingManager.sendModActionTemp(
 					this.client,

--- a/src/events/message/messageCreate.ts
+++ b/src/events/message/messageCreate.ts
@@ -32,10 +32,11 @@ export default class extends Event {
 		// checks if the guild is in the blacklist
 		if (this.client.blacklist.get(context.guild.id)) return;
 
-		await databaseManager.addToMessageToDB(message);
-
 		const mentionRegex = RegExp(`^<@!?${this.client.user.id}>`);
+		// Calling this will guarantee that the guild exists in the DB.
+		// If it doesn't already exists, we will just create it now
 		let guildCfg = await databaseManager.getConfig(context.guild);
+		await databaseManager.addToMessageToDB(message);
 
 		if ((guildCfg === undefined || guildCfg.prefix === undefined) && (context.content.startsWith(Config.prefix) || mentionRegex.test(context.content))) {
 			await databaseManager.deleteGuild(context.guild);

--- a/src/interactions/select/infraction.ts
+++ b/src/interactions/select/infraction.ts
@@ -21,7 +21,7 @@ export default async function (client: BulbBotClient, interaction: SelectMenuInt
 			ephemeral: true,
 		});
 
-	const user = await client.bulbutils.userObject(false, await client.users.fetch(inf.targetId));
+	const user = client.bulbutils.userObject(false, await client.users.fetch(inf.targetId));
 	const target = { tag: inf.target, id: inf.targetId };
 	const moderator = { tag: inf.moderator, id: inf.moderatorId };
 
@@ -33,17 +33,14 @@ export default async function (client: BulbBotClient, interaction: SelectMenuInt
 		created: moment(inf.createdAt).format("MMM Do YYYY, h:mm:ss a"),
 	});
 
-	if (inf.active !== "false" && inf.active !== "true") {
+	if (inf.timeout) {
 		description += await client.bulbutils.translate("infraction_info_expires", interaction.guild.id, {
-			expires: `${Emotes.status.ONLINE} ${moment(parseInt(inf.active)).format("MMM Do YYYY, h:mm:ss a")}`,
-		});
-	} else {
-		description += await client.bulbutils.translate("infraction_info_active", interaction.guild.id, {
-			active: client.bulbutils.prettify(inf.active),
+			expires: `${Emotes.status.ONLINE} ${moment(parseInt(inf.timeout)).format("MMM Do YYYY, h:mm:ss a")}`,
 		});
 	}
 
 	description += await client.bulbutils.translate("infraction_info_reason", interaction.guild.id, { reason: inf.reason });
+	description += await client.bulbutils.translate("infraction_info_active", interaction.guild.id, { active: client.bulbutils.prettify(`${inf.active}`) });
 
 	const image = inf.reason.match(ReasonImage);
 

--- a/src/prisma/migrations/20220625160923_active_to_boolean/migration.sql
+++ b/src/prisma/migrations/20220625160923_active_to_boolean/migration.sql
@@ -5,13 +5,13 @@
 
 */
 -- AlterTable
-ALTER TABLE "infractions" ADD COLUMN "active_tmp" VarChar(255);
-UPDATE "infractions" SET "active_tmp" = "active";
+ALTER TABLE "infractions" ADD COLUMN "timeout" VarChar(255);
+UPDATE "infractions" SET "timeout" = "active";
 ALTER TABLE "infractions" DROP COLUMN "active",
 ADD COLUMN     "active" BOOLEAN NOT NULL;
-UPDATE "infractions" SET "active" = true WHERE "active_tmp" = 'true';
-UPDATE "infractions" SET "active" = false WHERE "active_tmp" = 'false';
-ALTER TABLE "infractions" DROP COLUMN "active_tmp";
+UPDATE "infractions" SET "active" = true WHERE "timeout" <> 'false';
+UPDATE "infractions" SET "active" = false WHERE "timeout" = 'false';
+UPDATE "infractions" SET "timeout" = NULL WHERE "timeout" = 'false' OR "timeout" = 'true';
 
 -- CreateIndex
 CREATE INDEX "infractions_id_guildId_idx" ON "infractions"("id", "guildId");

--- a/src/prisma/migrations/20220625160923_active_to_boolean/migration.sql
+++ b/src/prisma/migrations/20220625160923_active_to_boolean/migration.sql
@@ -1,0 +1,17 @@
+/*
+  Warnings:
+
+  - Changed the type of `active` on the `infractions` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+
+*/
+-- AlterTable
+ALTER TABLE "infractions" ADD COLUMN "active_tmp" VarChar(255);
+UPDATE "infractions" SET "active_tmp" = "active";
+ALTER TABLE "infractions" DROP COLUMN "active",
+ADD COLUMN     "active" BOOLEAN NOT NULL;
+UPDATE "infractions" SET "active" = true WHERE "active_tmp" = 'true';
+UPDATE "infractions" SET "active" = false WHERE "active_tmp" = 'false';
+ALTER TABLE "infractions" DROP COLUMN "active_tmp";
+
+-- CreateIndex
+CREATE INDEX "infractions_id_guildId_idx" ON "infractions"("id", "guildId");

--- a/src/prisma/migrations/20220625162546_non_nullable_booleans/migration.sql
+++ b/src/prisma/migrations/20220625162546_non_nullable_booleans/migration.sql
@@ -1,0 +1,16 @@
+/*
+  Warnings:
+
+  - Made the column `enabled` on table `automods` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `actionsOnInfo` on table `guildConfigurations` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `rolesOnLeave` on table `guildConfigurations` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `manualNicknameInf` on table `guildConfigurations` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "automods" ALTER COLUMN "enabled" SET NOT NULL;
+
+-- AlterTable
+ALTER TABLE "guildConfigurations" ALTER COLUMN "actionsOnInfo" SET NOT NULL,
+ALTER COLUMN "rolesOnLeave" SET NOT NULL,
+ALTER COLUMN "manualNicknameInf" SET NOT NULL;

--- a/src/prisma/migrations/20220625165700_punishment_enum/migration.sql
+++ b/src/prisma/migrations/20220625165700_punishment_enum/migration.sql
@@ -1,0 +1,102 @@
+/*
+  Warnings:
+
+  - The `punishmentWebsite` column on the `automods` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The `punishmentInvites` column on the `automods` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The `punishmentWords` column on the `automods` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The `punishmentMentions` column on the `automods` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The `punishmentMessages` column on the `automods` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The `punishmentAvatarBans` column on the `automods` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+
+*/
+-- CreateEnum
+CREATE TYPE "AutomodPunishmentType" AS ENUM ('LOG', 'WARN', 'KICK', 'BAN');
+
+-- DuplicateData
+ALTER TABLE "automods" ADD COLUMN "punishmentWebsiteTmp" varchar(255) NULL;
+ALTER TABLE "automods" ADD COLUMN "punishmentInvitesTmp" varchar(255) NULL;
+ALTER TABLE "automods" ADD COLUMN "punishmentWordsTmp" varchar(255) NULL;
+ALTER TABLE "automods" ADD COLUMN "punishmentMentionsTmp" varchar(255) NULL;
+ALTER TABLE "automods" ADD COLUMN "punishmentMessagesTmp" varchar(255) NULL;
+ALTER TABLE "automods" ADD COLUMN "punishmentAvatarBansTmp" varchar(255) NULL;
+UPDATE "automods" SET
+  "punishmentWebsiteTmp" = "punishmentWebsite",
+  "punishmentInvitesTmp" = "punishmentInvites",
+  "punishmentWordsTmp" = "punishmentWords",
+  "punishmentMentionsTmp" = "punishmentMentions",
+  "punishmentMessagesTmp" = "punishmentMessages",
+  "punishmentAvatarBansTmp" = "punishmentAvatarBans";
+
+-- AlterTable
+ALTER TABLE "automods" DROP COLUMN "punishmentWebsite";
+ALTER TABLE "automods" ADD COLUMN     "punishmentWebsite" "AutomodPunishmentType";
+ALTER TABLE "automods" DROP COLUMN "punishmentInvites";
+ALTER TABLE "automods" ADD COLUMN     "punishmentInvites" "AutomodPunishmentType";
+ALTER TABLE "automods" DROP COLUMN "punishmentWords";
+ALTER TABLE "automods" ADD COLUMN     "punishmentWords" "AutomodPunishmentType";
+ALTER TABLE "automods" DROP COLUMN "punishmentMentions";
+ALTER TABLE "automods" ADD COLUMN     "punishmentMentions" "AutomodPunishmentType";
+ALTER TABLE "automods" DROP COLUMN "punishmentMessages";
+ALTER TABLE "automods" ADD COLUMN     "punishmentMessages" "AutomodPunishmentType";
+ALTER TABLE "automods" DROP COLUMN "punishmentAvatarBans";
+ALTER TABLE "automods" ADD COLUMN     "punishmentAvatarBans" "AutomodPunishmentType";
+
+-- RestoreData
+-- Website
+UPDATE "automods" SET "punishmentWebsite" = 'LOG' WHERE "punishmentWebsiteTmp" = 'LOG';
+UPDATE "automods" SET "punishmentWebsite" = 'WARN' WHERE "punishmentWebsiteTmp" = 'WARN';
+UPDATE "automods" SET "punishmentWebsite" = 'KICK' WHERE "punishmentWebsiteTmp" = 'KICK';
+UPDATE "automods" SET "punishmentWebsite" = 'BAN' WHERE "punishmentWebsiteTmp" = 'BAN';
+-- Invites
+UPDATE "automods" SET "punishmentInvites" = 'LOG' WHERE "punishmentInvitesTmp" = 'LOG';
+UPDATE "automods" SET "punishmentInvites" = 'WARN' WHERE "punishmentInvitesTmp" = 'WARN';
+UPDATE "automods" SET "punishmentInvites" = 'KICK' WHERE "punishmentInvitesTmp" = 'KICK';
+UPDATE "automods" SET "punishmentInvites" = 'BAN' WHERE "punishmentInvitesTmp" = 'BAN';
+-- Words
+UPDATE "automods" SET "punishmentWords" = 'LOG' WHERE "punishmentWordsTmp" = 'LOG';
+UPDATE "automods" SET "punishmentWords" = 'WARN' WHERE "punishmentWordsTmp" = 'WARN';
+UPDATE "automods" SET "punishmentWords" = 'KICK' WHERE "punishmentWordsTmp" = 'KICK';
+UPDATE "automods" SET "punishmentWords" = 'BAN' WHERE "punishmentWordsTmp" = 'BAN';
+-- Mentions
+UPDATE "automods" SET "punishmentMentions" = 'LOG' WHERE "punishmentMentionsTmp" = 'LOG';
+UPDATE "automods" SET "punishmentMentions" = 'WARN' WHERE "punishmentMentionsTmp" = 'WARN';
+UPDATE "automods" SET "punishmentMentions" = 'KICK' WHERE "punishmentMentionsTmp" = 'KICK';
+UPDATE "automods" SET "punishmentMentions" = 'BAN' WHERE "punishmentMentionsTmp" = 'BAN';
+-- Messages
+UPDATE "automods" SET "punishmentMessages" = 'LOG' WHERE "punishmentMessagesTmp" = 'LOG';
+UPDATE "automods" SET "punishmentMessages" = 'WARN' WHERE "punishmentMessagesTmp" = 'WARN';
+UPDATE "automods" SET "punishmentMessages" = 'KICK' WHERE "punishmentMessagesTmp" = 'KICK';
+UPDATE "automods" SET "punishmentMessages" = 'BAN' WHERE "punishmentMessagesTmp" = 'BAN';
+-- Avatar Bans
+UPDATE "automods" SET "punishmentAvatarBans" = 'LOG' WHERE "punishmentAvatarBansTmp" = 'LOG';
+UPDATE "automods" SET "punishmentAvatarBans" = 'WARN' WHERE "punishmentAvatarBansTmp" = 'WARN';
+UPDATE "automods" SET "punishmentAvatarBans" = 'KICK' WHERE "punishmentAvatarBansTmp" = 'KICK';
+UPDATE "automods" SET "punishmentAvatarBans" = 'BAN' WHERE "punishmentAvatarBansTmp" = 'BAN';
+
+-- Fallback strategy for unknown values
+UPDATE "automods"
+SET "punishmentWebsite" = 'LOG'
+WHERE "punishmentWebsiteTmp" IS NOT NULL AND "punishmentWebsite" IS NULL;
+UPDATE "automods"
+SET "punishmentInvites" = 'LOG'
+WHERE "punishmentInvitesTmp" IS NOT NULL AND "punishmentInvites" IS NULL;
+UPDATE "automods"
+SET "punishmentWords" = 'LOG'
+WHERE "punishmentWordsTmp" IS NOT NULL AND "punishmentWords" IS NULL;
+UPDATE "automods"
+SET "punishmentMentions" = 'LOG'
+WHERE "punishmentMentionsTmp" IS NOT NULL AND "punishmentMentions" IS NULL;
+UPDATE "automods"
+SET "punishmentMessages" = 'LOG'
+WHERE "punishmentMessagesTmp" IS NOT NULL AND "punishmentMessages" IS NULL;
+UPDATE "automods"
+SET "punishmentAvatarBans" = 'LOG'
+WHERE "punishmentAvatarBansTmp" IS NOT NULL AND "punishmentAvatarBans" IS NULL;
+
+-- DropDuplicates
+ALTER TABLE "automods" DROP COLUMN "punishmentWebsiteTmp";
+ALTER TABLE "automods" DROP COLUMN "punishmentInvitesTmp";
+ALTER TABLE "automods" DROP COLUMN "punishmentWordsTmp";
+ALTER TABLE "automods" DROP COLUMN "punishmentMentionsTmp";
+ALTER TABLE "automods" DROP COLUMN "punishmentMessagesTmp";
+ALTER TABLE "automods" DROP COLUMN "punishmentAvatarBansTmp";

--- a/src/prisma/migrations/20220625192345_non_nullable_bulb_guild/migration.sql
+++ b/src/prisma/migrations/20220625192345_non_nullable_bulb_guild/migration.sql
@@ -1,0 +1,24 @@
+/*
+  Warnings:
+
+  - Made the column `banpoolId` on table `banpoolSubscribers` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `guildId` on table `infractions` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `guildId` on table `messageLogs` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `guildId` on table `tempbans` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+DELETE FROM "banpoolSubscribers" WHERE "banpoolId" IS NULL;
+ALTER TABLE "banpoolSubscribers" ALTER COLUMN "banpoolId" SET NOT NULL;
+
+-- AlterTable
+DELETE FROM "infractions" WHERE "guildId" IS NULL;
+ALTER TABLE "infractions" ALTER COLUMN "guildId" SET NOT NULL;
+
+-- AlterTable
+DELETE FROM "messageLogs" WHERE "guildId" IS NULL;
+ALTER TABLE "messageLogs" ALTER COLUMN "guildId" SET NOT NULL;
+
+-- AlterTable
+DELETE FROM "tempbans" WHERE "guildId" IS NULL;
+ALTER TABLE "tempbans" ALTER COLUMN "guildId" SET NOT NULL;

--- a/src/prisma/migrations/20220625192746_drop_override_models/migration.sql
+++ b/src/prisma/migrations/20220625192746_drop_override_models/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - You are about to drop the `guildModerationRoles` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `guildOverrideCommands` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+DROP TABLE "guildModerationRoles";
+
+-- DropTable
+DROP TABLE "guildOverrideCommands";

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -37,7 +37,7 @@ model Automod {
   ignoreChannels       String[]               @db.VarChar(255)
   ignoreRoles          String[]               @db.VarChar(255)
   ignoreUsers          String[]               @db.VarChar(255)
-  bulbGuilds           BulbGuild?
+  bulbGuild            BulbGuild?
 
   @@map("automods")
 }
@@ -114,27 +114,27 @@ model GuildConfiguration {
   createdAt         DateTime   @default(now()) @db.Timestamptz(6)
   updatedAt         DateTime   @updatedAt @db.Timestamptz(6)
   manualNicknameInf Boolean    @default(false)
-  bulbGuilds        BulbGuild?
+  bulbGuild         BulbGuild?
 
   @@map("guildConfigurations")
 }
 
 model GuildLogging {
-  id         Int        @id @default(autoincrement())
-  modAction  String?    @db.VarChar(255)
-  banpool    String?    @db.VarChar(255)
-  automod    String?    @db.VarChar(255)
-  message    String?    @db.VarChar(255)
-  role       String?    @db.VarChar(255)
-  member     String?    @db.VarChar(255)
-  channel    String?    @db.VarChar(255)
-  thread     String?    @db.VarChar(255)
-  invite     String?    @db.VarChar(255)
-  joinLeave  String?    @db.VarChar(255)
-  other      String?    @db.VarChar(255)
-  createdAt  DateTime   @default(now()) @db.Timestamptz(6)
-  updatedAt  DateTime   @updatedAt @db.Timestamptz(6)
-  bulbGuilds BulbGuild?
+  id        Int        @id @default(autoincrement())
+  modAction String?    @db.VarChar(255)
+  banpool   String?    @db.VarChar(255)
+  automod   String?    @db.VarChar(255)
+  message   String?    @db.VarChar(255)
+  role      String?    @db.VarChar(255)
+  member    String?    @db.VarChar(255)
+  channel   String?    @db.VarChar(255)
+  thread    String?    @db.VarChar(255)
+  invite    String?    @db.VarChar(255)
+  joinLeave String?    @db.VarChar(255)
+  other     String?    @db.VarChar(255)
+  createdAt DateTime   @default(now()) @db.Timestamptz(6)
+  updatedAt DateTime   @updatedAt @db.Timestamptz(6)
+  bulbGuild BulbGuild?
 
   @@map("guildLoggings")
 }
@@ -148,9 +148,9 @@ model BulbGuild {
   guildConfigurationId Int                @unique
   guildLoggingId       Int                @unique
   automodId            Int                @unique
-  automod              Automod            @relation(fields: [automodId], references: [id], onDelete: SetNull)
-  guildConfiguration   GuildConfiguration @relation(fields: [guildConfigurationId], references: [id], onDelete: SetNull)
-  guildLogging         GuildLogging       @relation(fields: [guildLoggingId], references: [id], onDelete: SetNull)
+  automod              Automod            @relation(fields: [automodId], references: [id], onDelete: NoAction, onUpdate: Cascade)
+  guildConfiguration   GuildConfiguration @relation(fields: [guildConfigurationId], references: [id], onDelete: NoAction, onUpdate: Cascade)
+  guildLogging         GuildLogging       @relation(fields: [guildLoggingId], references: [id], onDelete: NoAction, onUpdate: Cascade)
   banpools             Banpool[]
   experiments          Experiment[]
   infractions          Infraction[]

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -164,6 +164,7 @@ model Infraction {
   id          Int       @id @default(autoincrement())
   action      String    @db.VarChar(255)
   active      Boolean
+  timeout     String?   @db.VarChar(255)
   reason      String    @db.VarChar(10000)
   target      String    @db.VarChar(255)
   targetId    String    @db.VarChar(255)

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -9,27 +9,34 @@ datasource db {
   referentialIntegrity = "prisma"
 }
 
+enum AutomodPunishmentType {
+  LOG
+  WARN
+  KICK
+  BAN
+}
+
 model Automod {
-  id                   Int        @id @default(autoincrement())
-  enabled              Boolean    @default(false)
-  websiteWhitelist     String[]   @db.VarChar(255)
-  punishmentWebsite    String?    @db.VarChar(255)
-  inviteWhitelist      String[]   @db.VarChar(255)
-  punishmentInvites    String?    @db.VarChar(255)
-  wordBlacklist        String[]   @db.VarChar(255)
-  wordBlacklistToken   String[]   @db.VarChar(255)
-  punishmentWords      String?    @db.VarChar(255)
-  limitMentions        Int?       @default(0)
-  punishmentMentions   String?    @db.VarChar(255)
-  timeoutMentions      Int?       @default(15000)
-  limitMessages        Int?       @default(0)
-  punishmentMessages   String?    @db.VarChar(255)
-  timeoutMessages      Int?       @default(10000)
-  avatarHashes         String[]   @db.VarChar(255)
-  punishmentAvatarBans String?    @db.VarChar(255)
-  ignoreChannels       String[]   @db.VarChar(255)
-  ignoreRoles          String[]   @db.VarChar(255)
-  ignoreUsers          String[]   @db.VarChar(255)
+  id                   Int                    @id @default(autoincrement())
+  enabled              Boolean                @default(false)
+  websiteWhitelist     String[]               @db.VarChar(255)
+  punishmentWebsite    AutomodPunishmentType?
+  inviteWhitelist      String[]               @db.VarChar(255)
+  punishmentInvites    AutomodPunishmentType?
+  wordBlacklist        String[]               @db.VarChar(255)
+  wordBlacklistToken   String[]               @db.VarChar(255)
+  punishmentWords      AutomodPunishmentType?
+  limitMentions        Int?                   @default(0)
+  punishmentMentions   AutomodPunishmentType?
+  timeoutMentions      Int?                   @default(15000)
+  limitMessages        Int?                   @default(0)
+  punishmentMessages   AutomodPunishmentType?
+  timeoutMessages      Int?                   @default(10000)
+  avatarHashes         String[]               @db.VarChar(255)
+  punishmentAvatarBans AutomodPunishmentType?
+  ignoreChannels       String[]               @db.VarChar(255)
+  ignoreRoles          String[]               @db.VarChar(255)
+  ignoreUsers          String[]               @db.VarChar(255)
   bulbGuilds           BulbGuild?
 
   @@map("automods")

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -11,7 +11,7 @@ datasource db {
 
 model Automod {
   id                   Int        @id @default(autoincrement())
-  enabled              Boolean?   @default(false)
+  enabled              Boolean    @default(false)
   websiteWhitelist     String[]   @db.VarChar(255)
   punishmentWebsite    String?    @db.VarChar(255)
   inviteWhitelist      String[]   @db.VarChar(255)
@@ -100,12 +100,12 @@ model GuildConfiguration {
   premiumGuild      Boolean    @default(false)
   autorole          String?    @db.VarChar(255)
   muteRole          String?    @db.VarChar(255)
-  actionsOnInfo     Boolean?   @default(false)
-  rolesOnLeave      Boolean?   @default(false)
+  actionsOnInfo     Boolean    @default(false)
+  rolesOnLeave      Boolean    @default(false)
   quickReasons      String[]   @db.VarChar(255)
   createdAt         DateTime   @default(now()) @db.Timestamptz(6)
   updatedAt         DateTime   @updatedAt @db.Timestamptz(6)
-  manualNicknameInf Boolean?   @default(false)
+  manualNicknameInf Boolean    @default(false)
   bulbGuilds        BulbGuild?
 
   @@map("guildConfigurations")

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -139,54 +139,23 @@ model GuildLogging {
   @@map("guildLoggings")
 }
 
-// @deprecated
-model GuildModerationRole {
-  id             Int        @id @default(autoincrement())
-  roleId         String     @db.VarChar(255)
-  clearanceLevel Int
-  createdAt      DateTime   @default(now()) @db.Timestamptz(6)
-  updatedAt      DateTime   @updatedAt @db.Timestamptz(6)
-  bulbGuildId    Int?       @map("guildId")
-  bulbGuild      BulbGuild? @relation(fields: [bulbGuildId], references: [id])
-
-  @@index([bulbGuildId])
-  @@map("guildModerationRoles")
-}
-
-// @deprecated
-model GuildOverrideCommand {
-  id             Int        @id @default(autoincrement())
-  enabled        Boolean
-  commandName    String     @db.VarChar(255)
-  clearanceLevel Int
-  createdAt      DateTime   @default(now()) @db.Timestamptz(6)
-  updatedAt      DateTime   @updatedAt @db.Timestamptz(6)
-  bulbGuildId    Int?       @map("guildId")
-  bulbGuild      BulbGuild? @relation(fields: [bulbGuildId], references: [id])
-
-  @@index([bulbGuildId])
-  @@map("guildOverrideCommands")
-}
-
 model BulbGuild {
-  id                    Int                    @id @default(autoincrement())
-  guildId               String                 @unique @db.VarChar(255)
-  name                  String                 @db.VarChar(255)
-  createdAt             DateTime               @default(now()) @db.Timestamptz(6)
-  updatedAt             DateTime               @updatedAt @db.Timestamptz(6)
-  guildConfigurationId  Int                    @unique
-  guildLoggingId        Int                    @unique
-  automodId             Int                    @unique
-  automod               Automod                @relation(fields: [automodId], references: [id], onDelete: SetNull)
-  guildConfiguration    GuildConfiguration     @relation(fields: [guildConfigurationId], references: [id], onDelete: SetNull)
-  guildLogging          GuildLogging           @relation(fields: [guildLoggingId], references: [id], onDelete: SetNull)
-  banpools              Banpool[]
-  experiments           Experiment[]
-  guildModerationRoles  GuildModerationRole[]
-  guildOverrideCommands GuildOverrideCommand[]
-  infractions           Infraction[]
-  messageLogs           MessageLog[]
-  tempbans              Tempban[]
+  id                   Int                @id @default(autoincrement())
+  guildId              String             @unique @db.VarChar(255)
+  name                 String             @db.VarChar(255)
+  createdAt            DateTime           @default(now()) @db.Timestamptz(6)
+  updatedAt            DateTime           @updatedAt @db.Timestamptz(6)
+  guildConfigurationId Int                @unique
+  guildLoggingId       Int                @unique
+  automodId            Int                @unique
+  automod              Automod            @relation(fields: [automodId], references: [id], onDelete: SetNull)
+  guildConfiguration   GuildConfiguration @relation(fields: [guildConfigurationId], references: [id], onDelete: SetNull)
+  guildLogging         GuildLogging       @relation(fields: [guildLoggingId], references: [id], onDelete: SetNull)
+  banpools             Banpool[]
+  experiments          Experiment[]
+  infractions          Infraction[]
+  messageLogs          MessageLog[]
+  tempbans             Tempban[]
 
   @@map("guilds")
 }

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -47,8 +47,8 @@ model BanpoolSubscriber {
   guildId   String   @db.VarChar(255)
   createdAt DateTime @default(now()) @db.Timestamptz(6)
   updatedAt DateTime @updatedAt @db.Timestamptz(6)
-  banpoolId Int?
-  banpool   Banpool? @relation(fields: [banpoolId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  banpoolId Int
+  banpool   Banpool  @relation(fields: [banpoolId], references: [id], onDelete: Cascade, onUpdate: Cascade)
 
   @@unique([guildId, banpoolId])
   @@index([guildId])
@@ -101,6 +101,7 @@ model Experiment {
 
 model GuildConfiguration {
   id                Int        @id @default(autoincrement())
+  // @deprecated
   prefix            String     @default("!") @db.VarChar(255)
   language          String     @default("en-US") @db.VarChar(255)
   timezone          String     @default("UTC") @db.VarChar(255)
@@ -138,6 +139,7 @@ model GuildLogging {
   @@map("guildLoggings")
 }
 
+// @deprecated
 model GuildModerationRole {
   id             Int        @id @default(autoincrement())
   roleId         String     @db.VarChar(255)
@@ -151,6 +153,7 @@ model GuildModerationRole {
   @@map("guildModerationRoles")
 }
 
+// @deprecated
 model GuildOverrideCommand {
   id             Int        @id @default(autoincrement())
   enabled        Boolean
@@ -189,18 +192,18 @@ model BulbGuild {
 }
 
 model Infraction {
-  id          Int        @id @default(autoincrement())
-  action      String     @db.VarChar(255)
+  id          Int       @id @default(autoincrement())
+  action      String    @db.VarChar(255)
   active      Boolean
-  reason      String     @db.VarChar(10000)
-  target      String     @db.VarChar(255)
-  targetId    String     @db.VarChar(255)
-  moderator   String     @db.VarChar(255)
-  moderatorId String     @db.VarChar(255)
-  createdAt   DateTime   @default(now()) @db.Timestamptz(6)
-  updatedAt   DateTime   @updatedAt @db.Timestamptz(6)
-  bulbGuildId Int?       @map("guildId")
-  bulbGuild   BulbGuild? @relation(fields: [bulbGuildId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  reason      String    @db.VarChar(10000)
+  target      String    @db.VarChar(255)
+  targetId    String    @db.VarChar(255)
+  moderator   String    @db.VarChar(255)
+  moderatorId String    @db.VarChar(255)
+  createdAt   DateTime  @default(now()) @db.Timestamptz(6)
+  updatedAt   DateTime  @updatedAt @db.Timestamptz(6)
+  bulbGuildId Int       @map("guildId")
+  bulbGuild   BulbGuild @relation(fields: [bulbGuildId], references: [id], onDelete: Cascade, onUpdate: Cascade)
 
   @@index([targetId])
   @@index([moderatorId])
@@ -210,18 +213,18 @@ model Infraction {
 }
 
 model MessageLog {
-  messageId   String     @id @db.VarChar(18)
-  channelId   String     @db.VarChar(18)
-  authorId    String     @db.VarChar(18)
-  authorTag   String     @db.VarChar(50)
-  content     String?    @db.VarChar(4000)
-  embed       Json?      @db.Json
-  sticker     Json?      @db.Json
-  attachments String[]   @db.VarChar(800)
-  createdAt   DateTime   @db.Timestamptz(6)
-  updatedAt   DateTime   @db.Timestamptz(6)
-  bulbGuildId Int?       @map("guildId")
-  bulbGuild   BulbGuild? @relation(fields: [bulbGuildId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  messageId   String    @id @db.VarChar(18)
+  channelId   String    @db.VarChar(18)
+  authorId    String    @db.VarChar(18)
+  authorTag   String    @db.VarChar(50)
+  content     String?   @db.VarChar(4000)
+  embed       Json?     @db.Json
+  sticker     Json?     @db.Json
+  attachments String[]  @db.VarChar(800)
+  createdAt   DateTime  @db.Timestamptz(6)
+  updatedAt   DateTime  @db.Timestamptz(6)
+  bulbGuildId Int       @map("guildId")
+  bulbGuild   BulbGuild @relation(fields: [bulbGuildId], references: [id], onDelete: Cascade, onUpdate: Cascade)
 
   @@index([bulbGuildId])
   @@index([authorId])
@@ -247,16 +250,16 @@ model Reminder {
 }
 
 model Tempban {
-  id          Int        @id @default(autoincrement())
-  targetTag   String     @db.VarChar(255)
-  targetId    String     @db.VarChar(255)
-  guildId     String     @map("gId") @db.VarChar(255)
-  reason      String     @db.VarChar(255)
+  id          Int       @id @default(autoincrement())
+  targetTag   String    @db.VarChar(255)
+  targetId    String    @db.VarChar(255)
+  guildId     String    @map("gId") @db.VarChar(255)
+  reason      String    @db.VarChar(255)
   expireTime  BigInt
-  createdAt   DateTime   @default(now()) @db.Timestamptz(6)
-  updatedAt   DateTime   @updatedAt @db.Timestamptz(6)
-  bulbGuildId Int?       @map("guildId")
-  bulbGuild   BulbGuild? @relation(fields: [bulbGuildId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  createdAt   DateTime  @default(now()) @db.Timestamptz(6)
+  updatedAt   DateTime  @updatedAt @db.Timestamptz(6)
+  bulbGuildId Int       @map("guildId")
+  bulbGuild   BulbGuild @relation(fields: [bulbGuildId], references: [id], onDelete: Cascade, onUpdate: Cascade)
 
   @@index([targetId])
   @@index([guildId])

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -184,7 +184,7 @@ model BulbGuild {
 model Infraction {
   id          Int        @id @default(autoincrement())
   action      String     @db.VarChar(255)
-  active      String     @db.VarChar(255)
+  active      Boolean
   reason      String     @db.VarChar(10000)
   target      String     @db.VarChar(255)
   targetId    String     @db.VarChar(255)

--- a/src/utils/managers/BanpoolManager.ts
+++ b/src/utils/managers/BanpoolManager.ts
@@ -21,7 +21,7 @@ export default class {
 		const { banpool } =
 			(await prisma.guildLogging.findFirst({
 				where: {
-					bulbGuilds: {
+					bulbGuild: {
 						guildId,
 					},
 				},

--- a/src/utils/managers/DatabaseManager.ts
+++ b/src/utils/managers/DatabaseManager.ts
@@ -87,16 +87,6 @@ export default class DatabaseManager {
 					bulbGuildId: bulbGuild.id,
 				},
 			}),
-			prisma.guildModerationRole.deleteMany({
-				where: {
-					bulbGuildId: bulbGuild.id,
-				},
-			}),
-			prisma.guildOverrideCommand.deleteMany({
-				where: {
-					bulbGuildId: bulbGuild.id,
-				},
-			}),
 			prisma.tempban.deleteMany({
 				where: {
 					bulbGuildId: bulbGuild.id,
@@ -172,8 +162,6 @@ export default class DatabaseManager {
 			include: {
 				guildConfiguration: true,
 				guildLogging: true,
-				guildOverrideCommands: true,
-				guildModerationRoles: true,
 				automod: true,
 				infractions: true,
 				tempbans: true,
@@ -398,6 +386,7 @@ export default class DatabaseManager {
 		if (!message.guild) {
 			throw new Error("message does not have a guild, cannot add to logs");
 		}
+
 		await prisma.messageLog.create({
 			data: {
 				messageId: message.id,


### PR DESCRIPTION
- Add precommit hook to run `prisma format` when changes are made to `schema.prisma`
- Change `Infraction.active` from String/varchar(255) to a Boolean
- Change all Boolean types to not be nullable
- Use an enum for possible punishment field values
- Make relation IDs non nullable
- Drop GuildModerationRole and GuildOverrideCommand
- Updates to the bot source code to properly handle the schema changes

Use `yarn db:deploy` to apply the schema changes, and then `yarn generate` to make prisma regenerate the TS front-end for the DB (the deploy command may do that automatically, I'm not sure)