### PR TITLE
Prefer fs promises over fs sync API

### DIFF
--- a/src/commands/Miscellaneous/jumbo.ts
+++ b/src/commands/Miscellaneous/jumbo.ts
@@ -1,5 +1,6 @@
 import { CommandInteraction } from "discord.js";
-import { existsSync, unlinkSync } from "fs";
+import { unlink } from "fs/promises";
+import { exists } from "../../utils/helpers";
 import { CustomEmote, GetEverythingAfterColon } from "../../utils/Regex";
 import axios from "axios";
 import sharp from "sharp";
@@ -88,7 +89,7 @@ export default class Jumbo extends ApplicationCommand {
 
 				if (emote === null) {
 					emoteName = await emojiUnicode(realList[i]).split(" ").join("-");
-					if (!existsSync(join(PATH, `${emoteName}.png`)))
+					if (!(await exists(join(PATH, `${emoteName}.png`))))
 						await this.downloadEmoji(`https://cdnjs.cloudflare.com/ajax/libs/twemoji/${TWEMOJI_VERSION}/svg/${emoteName}.svg`, "png", emote, emoteName, SIZE, PATH, TWEMOJI_VERSION);
 
 					jumboList.push(`${emoteName}.png`);
@@ -99,7 +100,7 @@ export default class Jumbo extends ApplicationCommand {
 					emoteName = emote[0];
 					if (!emoteName) continue;
 
-					if (!existsSync(join(PATH, `${emoteName}.${extension}`)))
+					if (!(await exists(join(PATH, `${emoteName}.${extension}`))))
 						await this.downloadEmoji(`https://cdn.discordapp.com/emojis/${emoteName}.${extension}?v=1&quality=lossless`, extension, emote, emoteName, SIZE, PATH, TWEMOJI_VERSION);
 					jumboList.push(`${emoteName}.${extension}`);
 				}
@@ -141,10 +142,10 @@ export default class Jumbo extends ApplicationCommand {
 					],
 					content: null,
 				});
-				unlinkSync(`${PATH}/final-${interaction.user.id}-${interaction.guild?.id}.png`);
+				await unlink(`${PATH}/final-${interaction.user.id}-${interaction.guild?.id}.png`);
 			}
 
-			unlinkSync(`${PATH}/${interaction.user.id}-${interaction.guild?.id}.${doesIncludeAnimatedEmoji ? "gif" : "png"}`);
+			await unlink(`${PATH}/${interaction.user.id}-${interaction.guild?.id}.${doesIncludeAnimatedEmoji ? "gif" : "png"}`);
 		} catch (err) {
 			this.client.log.error(`[JUMBO] ${interaction.user.tag} (${interaction.user.id}) had en error: `, err);
 			return void (await interaction.followUp({

--- a/src/commands/Moderation/archive/channel.ts
+++ b/src/commands/Moderation/archive/channel.ts
@@ -1,7 +1,7 @@
 import BulbBotClient from "../../../structures/BulbBotClient";
 import { CommandInteraction, Guild, GuildChannel } from "discord.js";
 import DatabaseManager from "../../../utils/managers/DatabaseManager";
-import { writeFileSync } from "fs";
+import { writeFile } from "fs/promises";
 import moment from "moment";
 import ApplicationSubCommand from "../../../structures/ApplicationSubCommand";
 import ApplicationCommand from "../../../structures/ApplicationCommand";
@@ -50,7 +50,7 @@ export default class ArchiveChannel extends ApplicationSubCommand {
 			archive += `${temp}`;
 		});
 
-		writeFileSync(`${__dirname}/../../../../files/archive-data-${interaction.guild?.id}-${channel.id}.txt`, archive);
+		await writeFile(`${__dirname}/../../../../files/archive-data-${interaction.guild?.id}-${channel.id}.txt`, archive);
 		await interaction.editReply(await this.client.bulbutils.translate("ban_message_dismiss", interaction.guild?.id, {}));
 		return void (await interaction.followUp({
 			content: await this.client.bulbutils.translate("archive_success", interaction.guild?.id, {

--- a/src/commands/Moderation/archive/user.ts
+++ b/src/commands/Moderation/archive/user.ts
@@ -1,7 +1,7 @@
 import BulbBotClient from "../../../structures/BulbBotClient";
 import { CommandInteraction, Guild, User } from "discord.js";
 import DatabaseManager from "../../../utils/managers/DatabaseManager";
-import { writeFileSync } from "fs";
+import { writeFile } from "fs/promises";
 import moment from "moment";
 import ApplicationSubCommand from "../../../structures/ApplicationSubCommand";
 import ApplicationCommand from "../../../structures/ApplicationCommand";
@@ -57,7 +57,7 @@ export default class ArchiveUser extends ApplicationSubCommand {
 			archive += `${temp}`;
 		});
 
-		writeFileSync(`${__dirname}/../../../../files/archive-data-${interaction.guild?.id}-${user.id}.txt`, archive);
+		await writeFile(`${__dirname}/../../../../files/archive-data-${interaction.guild?.id}-${user.id}.txt`, archive);
 		await interaction.editReply(await this.client.bulbutils.translate("ban_message_dismiss", interaction.guild?.id, {}));
 		return void (await interaction.followUp({
 			content: await this.client.bulbutils.translate("archive_success", interaction.guild?.id, {

--- a/src/commands/Moderation/purge/all.ts
+++ b/src/commands/Moderation/purge/all.ts
@@ -1,6 +1,6 @@
 import { Collection, CommandInteraction, Guild, GuildTextBasedChannel, Message } from "discord.js";
 import moment from "moment";
-import { writeFileSync } from "fs";
+import { writeFile } from "fs/promises";
 import LoggingManager from "../../../utils/managers/LoggingManager";
 import BulbBotClient from "../../../structures/BulbBotClient";
 import ApplicationSubCommand from "../../../structures/ApplicationSubCommand";
@@ -64,7 +64,7 @@ export default class PurgeAll extends ApplicationSubCommand {
 			await (interaction.channel as GuildTextBasedChannel)?.bulkDelete(msgs);
 		}
 
-		writeFileSync(`${__dirname}/../../../../files/PURGE-${interaction.guild?.id}.txt`, delMsgs);
+		await writeFile(`${__dirname}/../../../../files/PURGE-${interaction.guild?.id}.txt`, delMsgs);
 		await loggingManager.sendModActionFile(
 			this.client,
 			interaction.guild as Guild,

--- a/src/commands/Moderation/purge/between.ts
+++ b/src/commands/Moderation/purge/between.ts
@@ -1,6 +1,6 @@
 import { Collection, CommandInteraction, GuildTextBasedChannel, Message, Snowflake } from "discord.js";
 import moment from "moment";
-import { writeFileSync } from "fs";
+import { writeFile } from "fs/promises";
 import LoggingManager from "../../../utils/managers/LoggingManager";
 import BulbBotClient from "../../../structures/BulbBotClient";
 import ApplicationSubCommand from "../../../structures/ApplicationSubCommand";
@@ -79,7 +79,7 @@ export default class PurgeBetween extends ApplicationSubCommand {
 
 		await (interaction.channel as GuildTextBasedChannel)?.bulkDelete(messages);
 
-		writeFileSync(`${__dirname}/../../../../files/PURGE-${interaction.guild?.id}.txt`, delMsgs);
+		await writeFile(`${__dirname}/../../../../files/PURGE-${interaction.guild?.id}.txt`, delMsgs);
 
 		await loggingManager.sendModActionFile(
 			this.client,

--- a/src/commands/Moderation/purge/bots.ts
+++ b/src/commands/Moderation/purge/bots.ts
@@ -1,6 +1,6 @@
 import { Collection, CommandInteraction, Guild, GuildTextBasedChannel, Message, Snowflake } from "discord.js";
 import moment from "moment";
-import { writeFileSync } from "fs";
+import { writeFile } from "fs/promises";
 import LoggingManager from "../../../utils/managers/LoggingManager";
 import BulbBotClient from "../../../structures/BulbBotClient";
 import ApplicationSubCommand from "../../../structures/ApplicationSubCommand";
@@ -69,7 +69,7 @@ export default class PurgeBots extends ApplicationSubCommand {
 
 		await (interaction.channel as GuildTextBasedChannel)?.bulkDelete(messagesToPurge);
 
-		writeFileSync(`${__dirname}/../../../../files/PURGE-${interaction.guild?.id}.txt`, delMsgs);
+		await writeFile(`${__dirname}/../../../../files/PURGE-${interaction.guild?.id}.txt`, delMsgs);
 
 		await loggingManager.sendModActionFile(
 			this.client,

--- a/src/commands/Moderation/purge/contains.ts
+++ b/src/commands/Moderation/purge/contains.ts
@@ -1,6 +1,6 @@
 import { Collection, CommandInteraction, Guild, GuildTextBasedChannel, Message, Snowflake } from "discord.js";
 import moment from "moment";
-import { writeFileSync } from "fs";
+import { writeFile } from "fs/promises";
 import LoggingManager from "../../../utils/managers/LoggingManager";
 import BulbBotClient from "../../../structures/BulbBotClient";
 import ApplicationSubCommand from "../../../structures/ApplicationSubCommand";
@@ -77,7 +77,7 @@ export default class PurgeContains extends ApplicationSubCommand {
 
 		await (interaction.channel as GuildTextBasedChannel)?.bulkDelete(messagesToPurge);
 
-		writeFileSync(`${__dirname}/../../../../files/PURGE-${interaction.guild?.id}.txt`, delMsgs);
+		await writeFile(`${__dirname}/../../../../files/PURGE-${interaction.guild?.id}.txt`, delMsgs);
 
 		await loggingManager.sendModActionFile(
 			this.client,

--- a/src/commands/Moderation/purge/embeds.ts
+++ b/src/commands/Moderation/purge/embeds.ts
@@ -1,6 +1,6 @@
 import { Collection, CommandInteraction, Guild, GuildTextBasedChannel, Message, Snowflake } from "discord.js";
 import moment from "moment";
-import { writeFileSync } from "fs";
+import { writeFile } from "fs/promises";
 import LoggingManager from "../../../utils/managers/LoggingManager";
 import BulbBotClient from "../../../structures/BulbBotClient";
 import ApplicationSubCommand from "../../../structures/ApplicationSubCommand";
@@ -69,7 +69,7 @@ export default class PurgeEmbeds extends ApplicationSubCommand {
 
 		await (interaction.channel as GuildTextBasedChannel)?.bulkDelete(messagesToPurge);
 
-		writeFileSync(`${__dirname}/../../../../files/PURGE-${interaction.guild?.id}.txt`, delMsgs);
+		await writeFile(`${__dirname}/../../../../files/PURGE-${interaction.guild?.id}.txt`, delMsgs);
 
 		await loggingManager.sendModActionFile(
 			this.client,

--- a/src/commands/Moderation/purge/emojis.ts
+++ b/src/commands/Moderation/purge/emojis.ts
@@ -1,7 +1,7 @@
 import { Collection, CommandInteraction, Guild, GuildTextBasedChannel, Message, Snowflake } from "discord.js";
 import moment from "moment";
 import { CustomEmote, Emoji } from "../../../utils/Regex";
-import { writeFileSync } from "fs";
+import { writeFile } from "fs/promises";
 import LoggingManager from "../../../utils/managers/LoggingManager";
 import BulbBotClient from "../../../structures/BulbBotClient";
 import ApplicationSubCommand from "../../../structures/ApplicationSubCommand";
@@ -70,7 +70,7 @@ export default class PurgeEmojis extends ApplicationSubCommand {
 
 		await (interaction.channel as GuildTextBasedChannel)?.bulkDelete(messagesToPurge);
 
-		writeFileSync(`${__dirname}/../../../../files/PURGE-${interaction.guild?.id}.txt`, delMsgs);
+		await writeFile(`${__dirname}/../../../../files/PURGE-${interaction.guild?.id}.txt`, delMsgs);
 
 		await loggingManager.sendModActionFile(
 			this.client,

--- a/src/commands/Moderation/purge/images.ts
+++ b/src/commands/Moderation/purge/images.ts
@@ -1,6 +1,6 @@
 import { Collection, CommandInteraction, GuildTextBasedChannel, Message, Snowflake } from "discord.js";
 import moment from "moment";
-import { writeFileSync } from "fs";
+import { writeFile } from "fs/promises";
 import LoggingManager from "../../../utils/managers/LoggingManager";
 import BulbBotClient from "../../../structures/BulbBotClient";
 import ApplicationSubCommand from "../../../structures/ApplicationSubCommand";
@@ -69,7 +69,7 @@ export default class PurgeImages extends ApplicationSubCommand {
 
 		await (interaction.channel as GuildTextBasedChannel)?.bulkDelete(messagesToPurge);
 
-		writeFileSync(`${__dirname}/../../../../files/PURGE-${interaction.guild?.id}.txt`, delMsgs);
+		await writeFile(`${__dirname}/../../../../files/PURGE-${interaction.guild?.id}.txt`, delMsgs);
 
 		await loggingManager.sendModActionFile(
 			this.client,

--- a/src/commands/Moderation/purge/until.ts
+++ b/src/commands/Moderation/purge/until.ts
@@ -1,6 +1,6 @@
 import { Collection, CommandInteraction, GuildTextBasedChannel, Message } from "discord.js";
 import moment from "moment";
-import { writeFileSync } from "fs";
+import { writeFile } from "fs/promises";
 import LoggingManager from "../../../utils/managers/LoggingManager";
 import BulbBotClient from "../../../structures/BulbBotClient";
 import ApplicationSubCommand from "../../../structures/ApplicationSubCommand";
@@ -84,7 +84,7 @@ export default class PurgeUntil extends ApplicationSubCommand {
 				ephemeral: true,
 			});
 
-		writeFileSync(`${__dirname}/../../../../files/PURGE-${interaction.guild?.id}.txt`, delMsgs);
+		await writeFile(`${__dirname}/../../../../files/PURGE-${interaction.guild?.id}.txt`, delMsgs);
 
 		await loggingManager.sendModActionFile(
 			this.client,

--- a/src/commands/Moderation/purge/user.ts
+++ b/src/commands/Moderation/purge/user.ts
@@ -1,6 +1,6 @@
 import { Collection, CommandInteraction, Guild, GuildMember, GuildTextBasedChannel, Message, Snowflake } from "discord.js";
 import moment from "moment";
-import { writeFileSync } from "fs";
+import { writeFile } from "fs/promises";
 import LoggingManager from "../../../utils/managers/LoggingManager";
 import BulbBotClient from "../../../structures/BulbBotClient";
 import ApplicationSubCommand from "../../../structures/ApplicationSubCommand";
@@ -85,7 +85,7 @@ export default class PurgeUser extends ApplicationSubCommand {
 
 		await (interaction.channel as GuildTextBasedChannel)?.bulkDelete(messagesToPurge);
 
-		writeFileSync(`${__dirname}/../../../../files/PURGE-${interaction.guild?.id}.txt`, delMsgs);
+		await writeFile(`${__dirname}/../../../../files/PURGE-${interaction.guild?.id}.txt`, delMsgs);
 
 		await loggingManager.sendModActionFile(
 			this.client,

--- a/src/events/message/messageDelete.ts
+++ b/src/events/message/messageDelete.ts
@@ -1,7 +1,7 @@
 import Event from "../../structures/Event";
 import { Message, Util, Permissions, GuildAuditLogs, MessageAttachment, Guild, GuildChannelManager, TextBasedChannel, MessageEmbed } from "discord.js";
 import LoggingManager from "../../utils/managers/LoggingManager";
-import * as fs from "fs";
+import { writeFile } from "fs/promises";
 import { User } from "@sentry/node";
 import prisma from "../../prisma";
 import { isNullish } from "../../utils/helpers";
@@ -94,7 +94,7 @@ export default class extends Event {
 			});
 
 		if (msg.length >= 1850) {
-			fs.writeFileSync(`${__dirname}/../../../files/MESSAGE_DELETE-${guild.id}.txt`, content);
+			await writeFile(`${__dirname}/../../../files/MESSAGE_DELETE-${guild.id}.txt`, content);
 			await loggingManager.sendEventLog(
 				this.client,
 				guild,

--- a/src/events/message/messageUpdate.ts
+++ b/src/events/message/messageUpdate.ts
@@ -1,7 +1,7 @@
 import Event from "../../structures/Event";
 import { Message, Util } from "discord.js";
 import LoggingManager from "../../utils/managers/LoggingManager";
-import * as fs from "fs";
+import { writeFile } from "fs/promises";
 import AutoMod from "../../utils/AutoMod";
 import prisma from "../../prisma";
 
@@ -50,7 +50,7 @@ export default class extends Event {
 		});
 
 		if (msg.length >= 1850) {
-			fs.writeFileSync(`${__dirname}/../../../files/MESSAGE_UPDATE-${newMessage.guild.id}.txt`, `**B:** ${oldMessageContent}\n**A:** ${newMessage.content}`);
+			await writeFile(`${__dirname}/../../../files/MESSAGE_UPDATE-${newMessage.guild.id}.txt`, `**B:** ${oldMessageContent}\n**A:** ${newMessage.content}`);
 			await loggingManager.sendEventLog(
 				this.client,
 				newMessage.guild,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { init, Integrations } from "@sentry/node"; // @ts-expect-error
 import * as Tracing from "@sentry/tracing";
 import { startAllCrons } from "./utils/Crons";
 import { startPrometheus } from "./utils/Prometheus";
-import fs from "fs";
+import { readdirSync } from "fs";
 import i18next from "i18next";
 
 env.config({ path: `${__dirname}/../.env` });
@@ -21,7 +21,8 @@ const client: BulbBotClient = new BulbBotClient(config);
 const languagesPath = require("path").join(__dirname, "languages");
 
 const resources = {};
-fs.readdirSync(languagesPath).map((file) => {
+// This call is top-level so it must be sync. It occurs during startup so this is fine
+readdirSync(languagesPath).map((file) => {
 	const langName = file.split(".")[0];
 	resources[langName] = {
 		translation: require(`./languages/${langName}.json`),

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -2,6 +2,7 @@ import type { APIChannel, APIGuildMember } from "discord-api-types/v9";
 import { User, GuildMember, UserFlags, Role, GuildChannel } from "discord.js";
 import * as Emotes from "../emotes.json";
 import { APIRole } from "discord-api-types/v10";
+import { realpath } from "fs/promises";
 
 // Miscellaneous helper functions & idioms
 // So they don't need to be referenced from bulbutils
@@ -154,3 +155,14 @@ export const unpackSettled = <T>(settled: PromiseSettledResult<T>[]): T[] => {
 	}
 	return resolved;
 };
+
+// FS exists is deprecated for various reasons, but in our usecase we need to check
+/**
+ * Pollyfill of fs.exists in promise form. fs.exists is deprecated for various reasons,
+ * however in our usage (as of writing) it really is the correct thing to do. Rather than
+ * use the undeprecated existsSync, we should try to stick with async options
+ */
+export const exists = (...args: Parameters<typeof realpath>): Promise<boolean> =>
+	realpath(...args)
+		.then(() => true)
+		.catch(() => false);


### PR DESCRIPTION
File IO operations are inherently asynchronous, as JS has to ask the OS to do something, and then there's nothing more for JS to do until the OS is done. When using functions from  the fs sync API, JS will make the system call and then stop and wait and do absolutely nothing until the OS completes the task.This is bad. Instead, we want to use promises, particularly in code run during normal bot runtime e.g. command bodies. When using the promises API, the calls are async, so JS will ask OS to do the file task, but then it will suspend that thread and be able to go handle any other JS stuff that needs to happen, like other command invocations or handling events from anywhere, until the OS completes the task and the thread with the resolved promise is picked back up from the task queue. This is much better, and will especially be important for scaling. I don't think we've seen issues from this yet (none that I'm aware of anyway), but we would've eventually